### PR TITLE
e-mail and parkour updates

### DIFF
--- a/BRB/ET.py
+++ b/BRB/ET.py
@@ -6,7 +6,7 @@ import json
 import BRB.misc
 from BRB.logger import log
 import pandas as pd
-
+from pathlib import Path
 
 def getNReads(d):
     """
@@ -56,7 +56,9 @@ def getOffSpeciesRate(d, organism = None) -> float:
     with open(fname) as f:
         for line in f:
             if org_map[organism] in line:
-                off = float(line.strip().split()[0])/100
+                off = 1-(float(line.strip().split()[0])/100)
+    # off-species actually means fraction of non-expected organism reads !
+    # off-species reads vs of-species reads ;)
     log.info(f"confident reads for {fname} = {off}")
     return off
 
@@ -198,9 +200,11 @@ def sendToParkour(config, msg):
     log.info(f"sendToParkour: Sending {d} to Parkour")
     res = requests.post(config.get("Parkour", "ResultsURL"), auth=(config.get("Parkour", "user"), config.get("Parkour", "password")), data=d, verify=config.get("Parkour", "cert"))
     log.info(f"sendToParkour return {res}")
+    return res
 
 
-def phoneHome(config, outputDir, pipeline, samples_tuples, organism):
+
+def phoneHome(config, outputDir, pipeline, samples_tuples, organism, project, libType):
     """
     Return metrics to Parkour, the results are in outputDir and pipeline needs to be run on them
     """
@@ -224,26 +228,32 @@ def phoneHome(config, outputDir, pipeline, samples_tuples, organism):
         msg = m
 
     if msg is not None:
-        sendToParkour(config, msg)
+        ret = sendToParkour(config, msg)
+    else:
+        ret = None
+    
+    return [project, organism, libType, pipeline, 'success', ret]
 
 
 def telegraphHome(config, group, project, skipList, organism=None):
     """
     The skipList is a list of samples/libraries for which we don't run a pipeline, but it'd be nice to still send back sequencing metrics
-
-    ([library, sampleName])
+    Structure of skipList:
+    [library, sampleName, libraryType]
     """
+    log.info(f"telegraphHome triggered for {project}")
     # make a fake output directory path
-    baseDir = "{}/{}/{}/{}/Analysis_{}".format(config.get('Paths', 'groupData'),
-                                                            BRB.misc.pacifier(group),
-                                                            BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                            config.get('Options', 'runID'),
-                                                            BRB.misc.pacifier(project))
-    outputDir = os.path.join(baseDir, "DNA_mouse") # does not matter what it is, it is just a generic name. No pipeline is run on these data
+    baseDir = Path(
+        config.get('Paths', 'groupData'),
+        BRB.misc.pacifier(group),
+        BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
+        config.get('Options', 'runID'),
+        BRB.misc.pacifier(project)
+    )
+    # Mock path
+    outputDir = baseDir / "DNA_mouse"
     samples_id = [row[0] for row in skipList]
-    print("SAMPLESID = {}".format(samples_id))
     baseDict, sample2lib = getBaseStatistics(config, outputDir, samples_id, organism)
-    print("telegraphHome: baseDict: {}, sample2lib: {}".format(baseDict, sample2lib))
     # Reformat into a matrix
     m = []
     for k, v in baseDict.items():
@@ -251,5 +261,8 @@ def telegraphHome(config, group, project, skipList, organism=None):
                   'reads_pf_sequenced': v[1],
                   'confident_reads': v[2],
                   'optical_duplicates': v[3]})
-    sendToParkour(config, m)
-    return "Sent information on {} libraries from project {} from the {} group to Parkour\n".format(len(skipList), project, group)
+    ret = sendToParkour(config, m)
+    # Format the libtypes
+    libTypes = ','.join(set([i[2] for i in skipList]))
+    # [project, organism, libtypes, workflow, workflow status, parkour status, sambaUpdate]
+    return [project, organism, libTypes, None, None, ret, False]

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -594,7 +594,7 @@ def GetResults(config, project, libraries):
                     msg = msg + [BRB.ET.phoneHome(config, outputDir, pipeline, tuples, organism, project, libraryType) + [sambaUpdate]]
                     log.info(f"Processed project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {organism}")
                 else:
-                    msg = msg + [[project, organism, libType, pipeline, 'FAILED', ret, sambaupdate]]
+                    msg = msg + [[project, organism, libraryType, pipeline, 'FAILED', 'not updated', sambaUpdate]]
                     log.warning(f"FAILED project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {organism}")
     # In case there is an external_skipList, there shouldn't be a skipList !
     if external_skipList:

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -591,7 +591,6 @@ def GetResults(config, project, libraries):
                 #hence the pacifier is applied on the project in each pipeline separately
                 outputDir, rv, sambaUpdate = globals()[pipeline](config, group, project, organism, libraryType, tuples)
                 if rv == 0:
-                    #try:
                     msg = msg + [BRB.ET.phoneHome(config, outputDir, pipeline, tuples, organism, project, libraryType) + [sambaUpdate]]
                     log.info(f"Processed project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {organism}")
                 else:

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -79,7 +79,8 @@ def relinkFiles(config, group, project, organism, libraryType, tuples):
     mqcf = os.path.join(outputDir, 'multiQC', 'multiqc_report.html')
     if os.path.exists(mqcf):
         log.info(f"Multiqc report found for {group} project {project}.")
-        of = Path(config.get('Paths', 'bioinfoCoreDir')) / 'Analysis' + project + '_multiqc.html'
+        oname = 'Analysis' + project + '_multiqc.html'
+        of = Path(config.get('Paths', 'bioinfoCoreDir')) / oname
         log.info(f"Trying to copy mqc report to {of}.")
         shutil.copyfile(mqcf, of)
     else:
@@ -131,7 +132,7 @@ def copyCellRanger(config, d):
         shutil.copyfile(fname, nname)
         # to bioinfocore dir
         shutil.copyfile(fname, bioinfoCoreDirPath)
-        log.warning("copyCellRanger from {} to {} failed.".format(fname, bioinfoCoreDirPath))
+    
 
 
 def copyRELACS(config, d):
@@ -169,26 +170,15 @@ def tidyUpABit(d):
     """
     Reduce the number of files in the analysis folder.
     """
-    shutil.rmtree(os.path.join(d, 'cluster_logs'))
-    os.unlink(os.path.join(d, 'config.yaml'))
-    shutil.rmtree(os.path.join(d, '.snakemake'))
-    # multiqc data
-    mqc_log = os.path.join(d, 'multiQC', 'multiqc_data', 'multiqc.log')
-    mqc_out = os.path.join(d, 'multiQC', 'multiQC.out')
-    mqc_err = os.path.join(d, 'multiQC', 'multiQC.err')
-    if os.path.exists(mqc_log):
-        os.unlink(mqc_log)
-    if os.path.exists(mqc_out):
-        os.unlink(mqc_out)
-    if os.path.exists(mqc_err):
-        os.unlink(mqc_err)
-
-    for f in glob.glob(os.path.join(d, '*.log')):
-        os.unlink(f)
-
-    for d2 in glob.glob(os.path.join(d, 'FASTQ*')):
-        shutil.rmtree(d2)
-
+    for _d in ['clusters_logs', '.snakemake']:
+        _ = os.path.join(d, _d)
+        if os.path.exists(_):
+            shutil.rmtree(_)
+    (Path(d) / 'config.yaml').unlink(missing_ok=True)
+    (Path(d) / 'multiQC' / 'multiqc_data' / 'multiqc.log').unlink(missing_ok=True)
+    (Path(d) / 'multiQC' / 'multiQC.out').unlink(missing_ok=True)
+    (Path(d) / 'multiQC' / 'multiQC.err').unlink(missing_ok=True)
+    (Path(d) / 'config.yaml').unlink(missing_ok=True)
 
 def stripRights(d):
     # Strip rights.
@@ -215,7 +205,7 @@ def RNA(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
     org = organism2Org(config, organism)
     CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
@@ -231,19 +221,12 @@ def RNA(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     removeLinkFiles(outputDir)
     relinkFiles(config, group, project, organism, libraryType, tuples)
     tidyUpABit(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
-
-
-    baseDir = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
-                                                           BRB.misc.pacifier(group),
-                                                           BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                           config.get('Options', 'runID'),
-                                                           BRB.misc.pacifier(project))
+    return outputDir, 0, False
 
 
 def RELACS(config, group, project, organism, libraryType, tuples):
@@ -258,13 +241,13 @@ def RELACS(config, group, project, organism, libraryType, tuples):
 
     outputDir = createPath(config, group, BRB.misc.pacifier(project), organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, True
 
     sampleSheet = "/dont_touch_this/solexa_runs/{}/RELACS_Project_{}.txt".format(runID, BRB.misc.pacifier(project))
     if not os.path.exists(sampleSheet) and not os.path.exists(os.path.join(outputDir, "RELACS_sampleSheet.txt")):
         log.critical("RELACS: wrong samplesheet name: {}".format(sampleSheet))
         print("wrong samplesheet name!", sampleSheet)
-        return None, 1
+        return None, 1, False
 
     project = BRB.misc.pacifier(project)
     baseDir = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
@@ -289,7 +272,7 @@ def RELACS(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True, cwd=outputDir)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
 
     # clean up
     for d in unlinkDirs:
@@ -312,13 +295,13 @@ def RELACS(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     removeLinkFiles(outputDir)
     tidyUpABit(outputDir)
     copyRELACS(config,os.path.join(outputDir, "RELACS_demultiplexing"))
     stripRights(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, True
 
 
 def DNA(config, group, project, organism, libraryType, tuples):
@@ -339,7 +322,7 @@ def DNA(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
     org = organism2Org(config, organism)
     CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
@@ -352,13 +335,13 @@ def DNA(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     removeLinkFiles(outputDir)
     relinkFiles(config, group, project, organism, libraryType, tuples)
     tidyUpABit(outputDir)
     stripRights(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, False
 
 
 def WGBS(config, group, project, organism, libraryType, tuples):
@@ -372,7 +355,7 @@ def WGBS(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
     org = organism2Org(config, organism)
     CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
@@ -380,13 +363,13 @@ def WGBS(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     removeLinkFiles(outputDir)
     relinkFiles(config, group, project, organism, libraryType, tuples)
     tidyUpABit(outputDir)
     stripRights(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, False
 
 
 def ATAC(config, group, project, organism, libraryType, tuples):
@@ -397,12 +380,12 @@ def ATAC(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, False
 
     if not os.path.exists(os.path.join(outputDir, "DNA.done")):
         outputDir, rv = DNA(config, group, project, organism, libraryType, tuples)
         if rv != 0:
-            return outputDir, rv
+            return outputDir, rv, False
 
         removeDone(outputDir)
         touchDone(outputDir, "DNA.done")
@@ -412,11 +395,11 @@ def ATAC(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     tidyUpABit(outputDir)
     stripRights(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, False
 
 
 def scRNAseq(config, group, project, organism, libraryType, tuples):
@@ -431,7 +414,7 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, True
 
     org = organism2Org(config, organism)
     if tuples[0][2] == 'Chromium_NextGEM_SingleCell3Prime_GeneExpression_v3.1_DualIndex':
@@ -440,10 +423,12 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
         try:
             subprocess.check_call(' '.join(CMD), shell=True)
         except:
-            return outputDir, 1
+            return outputDir, 1, False
         removeLinkFiles(outputDir)
         tidyUpABit(outputDir)
         stripRights(outputDir)
+        copyCellRanger(config,outputDir)
+        sambaUpdate = True
     elif tuples[0][2] == "Cel-Seq 2 for single cell RNA-Seq":
         PE = linkFiles(config, group, project, outputDir, tuples)
         CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
@@ -451,14 +436,14 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
         try:
             subprocess.check_call(' '.join(CMD), shell=True)
         except:
-            return outputDir, 1
+            return outputDir, 1, False
         removeLinkFiles(outputDir)
         tidyUpABit(outputDir)
         stripRights(outputDir)
-        
-    copyCellRanger(config,outputDir)
+        sambaUpdate = False
+
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, sambaUpdate
 
 
 def HiC(config, group, project, organism, libraryType, tuples):
@@ -476,7 +461,7 @@ def HiC(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
     org = organism2Org(config, organism)
     CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
@@ -484,13 +469,13 @@ def HiC(config, group, project, organism, libraryType, tuples):
     try:
         subprocess.check_call(' '.join(CMD), shell=True)
     except:
-        return outputDir, 1
+        return outputDir, 1, False
     removeLinkFiles(outputDir)
     relinkFiles(config, group, project, organism, libraryType, tuples)
     tidyUpABit(outputDir)
     stripRights(outputDir)
     touchDone(outputDir)
-    return outputDir, 0
+    return outputDir, 0, False
 
 
 def scATAC(config, group, project, organism, libraryType, tuples):
@@ -501,7 +486,7 @@ def scATAC(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     outputDir = createPath(config, group, project, organism, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
-        return outputDir, 0
+        return outputDir, 0, True
     runID = config.get('Options', 'runID').split("_lanes")[0]
     org = organism2Org(config, organism)
     if (
@@ -523,11 +508,12 @@ def scATAC(config, group, project, organism, libraryType, tuples):
         try:
             subprocess.check_call(CMD, shell=True)
         except:
-            return outputDir, 1
+            return outputDir, 1, False
         # removeLinkFiles(outputDir)
+        copyCellRanger(config,outputDir)
         stripRights(outputDir)
         tidyUpABit(outputDir)
-    return outputDir, 0
+    return outputDir, 0, True
 
 
 def GetResults(config, project, libraries):
@@ -548,12 +534,14 @@ def GetResults(config, project, libraries):
     try:
         group = project.split("_")[-1].split("-")[0].lower()
         group = BRB.misc.pacifier(group)
-        dataPath = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
-                                                            group,
-                                                            BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                            config.get('Options', 'runID'),
-                                                            BRB.misc.pacifier(project))
-        log.info("Processing {}".format(dataPath))
+        dataPath = Path(
+            config.get('Paths', 'groupData'),
+            group,
+            BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
+            config.get('Options', 'runID'),
+            'Project_' + BRB.misc.pacifier(project)
+        )
+        log.info(f"Processing {dataPath}")
     except:
         print("external data")
         ignore = True
@@ -568,13 +556,13 @@ def GetResults(config, project, libraries):
         sampleName, libraryType, libraryProtocol, organism, indexType, requestDepth = v
         # Extra checks to see where we miss out
         if libraryType in validLibraryTypes:
-            log.info("ValidLibraryType = {}".format(libraryType))
+            log.info(f"ValidLibraryType = {libraryType}")
         else:
-            log.info("Not a ValidLibraryType = {}".format(libraryType))
+            log.info(f"Not a ValidLibraryType = {libraryType}")
         if organism in validOrganisms:
-            log.info("ValidOrganism = {}".format(organism))
+            log.info(f"ValidOrganism = {organism}")
         else:
-            log.info("Not a ValidOrganism = {}".format(organism))
+            log.info(f"Not a ValidOrganism = {organism}")
         if libraryType in validLibraryTypes and organism in validOrganisms and (ignore==False or libraryType in config.get('external','LibraryTypes')):
             idx = validLibraryTypes[libraryType]
             pipeline = pipelines[idx]
@@ -585,27 +573,33 @@ def GetResults(config, project, libraries):
             if libraryType not in analysisTypes[pipeline][organism]:
                 analysisTypes[pipeline][organism][libraryType] = list()
             analysisTypes[pipeline][organism][libraryType].append([library, sampleName, libraryProtocol, ignore])
-            log.debug("Considering analysis types: {}".format(",".join(analysisTypes)))
+            log.debug(f"Considering analysis types: {analysisTypes}")
         else:
             if ignore == False:
-               skipList.append([library, sampleName])
+               skipList.append([library, sampleName, libraryType])
             else:
-               external_skipList.append([library, sampleName])
-    msg = ""
+               external_skipList.append([library, sampleName, libraryType])
+    msg = []
     if len(skipList):
         for i in skipList:
-            msg += "Skipping {}/{} on {}.\n".format(i[0], i[1], organism)
-        msg += BRB.ET.telegraphHome(config, group, BRB.misc.pacifier(project), skipList, organism)
+            log.info(f"Skipping sample {i[0]}/{i[0]} ({organism} - project {BRB.misc.pacifier(project)}).\n")
+        msg = msg + [BRB.ET.telegraphHome(config, group, BRB.misc.pacifier(project), skipList, organism)]
     for pipeline, v in analysisTypes.items():
         for organism, v2 in v.items():
             for libraryType, tuples in v2.items():
                 #RELACS needs the unpacified project name to copy the original sample sheet to the dest dir
                 #hence the pacifier is applied on the project in each pipeline separately
-                outputDir, rv = globals()[pipeline](config, group, project, organism, libraryType, tuples)
+                outputDir, rv, sambaUpdate = globals()[pipeline](config, group, project, organism, libraryType, tuples)
                 if rv == 0:
                     #try:
-                    BRB.ET.phoneHome(config, outputDir, pipeline, tuples, organism)
-                    msg += 'Processed project {} with the {} pipeline. The samples were of type {} from a {}.\n'.format(BRB.misc.pacifier(project), pipeline, libraryType, organism)
+                    msg = msg + [BRB.ET.phoneHome(config, outputDir, pipeline, tuples, organism, project, libraryType) + [sambaUpdate]]
+                    log.info(f"Processed project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {organism}")
                 else:
-                    msg += "I received an error processing {}_{}_{}_{} for you.\n".format(BRB.misc.pacifier(project), pipeline, libraryType, organism)
+                    msg = msg + [[project, organism, libType, pipeline, 'FAILED', ret, sambaupdate]]
+                    log.warning(f"FAILED project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {organism}")
+    # In case there is an external_skipList, there shouldn't be a skipList !
+    if external_skipList:
+        assert not skipList
+        libTypes = ','.join(set([i[2] for i in external_skipList]))
+        msg = msg + [project, organism, libTypes, None, None, None, False]
     return msg

--- a/BRB/email.py
+++ b/BRB/email.py
@@ -33,14 +33,14 @@ def finishedEmail(config, msg):
         if [i[4] for i in msg].count('success') == len(msg):
             recipient = config.get("Email","deepSeq")
             _html.add(div(
-                "Post-processing is ready, deepSeq's sambda drive is updated for at least one project.",
+                f"Post-processing is ready, Samba drive is updated for {[i[6] for i in msg].count(True)} project(s).",
                 br()
             ))
-    
+
     mailer['To'] = recipient
     # Table
     tabHead = ['Project', 'organism', 'libraryType', 'workflow', 'workflow_status', 'parkour_status', 'sambaUpdate']
-    message = tabulate(
+    message =  _html.render() + '\n\n' + tabulate(
         msg, tabHead, tablefmt="html", disable_numparse=True
     )
 

--- a/BRB/email.py
+++ b/BRB/email.py
@@ -1,6 +1,10 @@
 import smtplib
+from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from importlib.metadata import version
+from dominate.tags import html, div, br
+from tabulate import tabulate
+from BRB.logger import log
 
 def errorEmail(config, errTuple, msg) :
     msg = MIMEText(msg + "\nError type: %s\nError value: %s\n%s\n" % (errTuple[0], errTuple[1], errTuple[2]))
@@ -13,15 +17,41 @@ def errorEmail(config, errTuple, msg) :
     s.quit()
 
 
-def finishedEmail(config, msg) :
-    message = "Flow cell: {}\n".format(config.get("Options","runID"))
-    message += msg
+def finishedEmail(config, msg):
+    mailer = MIMEMultipart('alternative')
+    mailer['Subject'] = f"[BigRedButton {version("BRB")}] {config.get("Options","runID")} processed"
+    mailer['From'] = config.get("Email","fromAddress")
+    
+    # Create the table head
+    _html = html()
+    # Default recipient is finishedTo (bioinfocore)
+    recipient = config.get("Email","finishedTo")
+    # Inform deepseq too if we have a sambaUpdate:
+    if any([i[6] for i in msg]):
+        log.info("At least one sambaUpdate true in msg")
+        # Only inform deepseq if all workflows are succesfull (combat spam)
+        if [i[4] for i in msg].count('success') == len(msg):
+            recipient = config.get("Email","deepSeq")
+            _html.add(div(
+                "Post-processing is ready, deepSeq's sambda drive is updated for at least one project.",
+                br()
+            ))
+    
+    mailer['To'] = recipient
+    # Table
+    tabHead = ['Project', 'organism', 'libraryType', 'workflow', 'workflow_status', 'parkour_status', 'sambaUpdate']
+    message = tabulate(
+        msg, tabHead, tablefmt="html", disable_numparse=True
+    )
 
-    msg = MIMEText(message)
-    msg['Subject'] = f"[BigRedButton {version("BRB")}] {config.get("Options","runID")} processed"
-    msg['From'] = config.get("Email","fromAddress")
-    msg['To'] = config.get("Email","finishedTo")
-
-    s = smtplib.SMTP(config.get("Email","host"))
-    s.send_message(msg)
+    email = MIMEText(message, 'html')
+    mailer.attach(email)
+    
+    s = smtplib.SMTP(config.get("Email", "host"))
+    
+    s.sendmail(
+        config.get("Email","fromAddress"),
+        recipient.split(','),
+        mailer.as_string()
+    )
     s.quit()

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -1,4 +1,3 @@
-import sys
 import glob
 import requests
 from rich import print
@@ -55,5 +54,5 @@ def newFlowCell(config):
                 ParkourDict = None
                 continue
             return config, ParkourDict
-    print(f"No new flow cells found...")
+    print("No new flow cells found...")
     return config, None

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -55,5 +55,5 @@ def newFlowCell(config):
                 ParkourDict = None
                 continue
             return config, ParkourDict
-
+    print(f"No new flow cells found...")
     return config, None

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -1,25 +1,28 @@
-'''
-This file includes anything involved in finding new flow cells to process.
-
-Note that this includes anything done after a flow cell has been processed,
-such as marking it as having been processed and sending emails.
-'''
-
-import os.path
 import sys
 import glob
 import requests
+from rich import print
+from pathlib import Path
+from BRB.logger import log
 
 
-#Returns True on processed, False on unprocessed
 def flowCellProcessed(config):
-    path = "{}/{}/analysis.done".format(config.get("Paths","baseData"), config.get("Options","runID"))
-    return os.path.exists(path)
+    return Path(
+        config.get("Paths","baseData"),
+        config.get("Options","runID"),
+        'analysis.done'
+    ).exists()
 
 
 def markFinished(config):
-    open("{}/{}/analysis.done".format(config["Paths"]["baseData"], config["Options"]["runID"]), "w").close()
-    return
+    _p = Path(
+        config["Paths"]["baseData"],
+        config["Options"]["runID"],
+        'analysis.done'
+    )
+    _p.touch()
+    log.info(f"{_p} created, flow cell processed.")
+    print(f"{_p} created, flow cell processed.")
 
 
 def queryParkour(config):
@@ -43,7 +46,7 @@ def newFlowCell(config):
             continue
 
         if not flowCellProcessed(config):
-            sys.stderr.write("Found a new flow cell: %s\n" % config.get("Options","runID"))
+            print(f"Found new flow cell: [green]{config.get("Options","runID")}[/green]")
             # Query parkour to see if there's anything to be done for this
             ParkourDict = queryParkour(config)
             if len(ParkourDict) == 0:

--- a/BigRedButton.ini
+++ b/BigRedButton.ini
@@ -41,6 +41,7 @@ cert=path/to/cert.pem
 [Email]
 #Lists of recipients can be comma separated
 errorTo=mustermann@ie-freiburg.mpg.de
-finishedTo=mustermann@ie-freiburg.mpg.de, another.example@ie-freiburg.mpg.de
+finishedTo=mustermann@ie-freiburg.mpg.de
+deepSeq=mustermann@ie-freiburg.mpg.de, another.example@ie-freiburg.mpg.de
 fromAddress=some.user@ie-freiburg.mpg.de
 host=localhost

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
   "requests >= 2.31",
   "certifi >= 2023",
   "pyyaml >= 6.0",
-  "rich_click >= 1.8.3"
+  "rich_click >= 1.8.3",
+  "dominate >= 2.9.1",
+  "tabulate >= 0.9.0"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "dixitque PI fiat computationēs et facta est computationēs et vidit PI computationēs quod esset bona"
 readme = "README.md"
-version = '0.0.2'
+version = '0.0.3'
 requires-python = ">= 3.10"
 dependencies = [
   "bioblend >= 1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ BigRedButton = "BRB.run:run_brb"
 demultiplex_relacs = "BRB.demultiplex_relacs:main"
 
 [tool.ruff]
-ignore = [
+lint.ignore = [
   "E722",
   "F841",
   "E712"


### PR DESCRIPTION
 - fix off species metric, make sure it's compatible with old organisms too. Closes #20 
 - standardized emails. Closes #66 
 - Deepseq get an email if all wfs passed and samba drive is updated. Closes #68, #34
 - Fix metrics pushed over to parkour, relacs is properly escaped for now. Closes #21, #30
 - started purging os.paths in favor of pathlibs, though this is not finalized yet.