### PR TITLE
directories with spaces are always tricky

### DIFF
--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -8,6 +8,34 @@ from BRB.logger import log
 import stat
 from pathlib import Path
 
+
+# This is an interim solution. Ultimately, validOrganisms and organismNames,
+# or their mappings to human-readable strings,
+# should all be handled in a single database table.
+ORGANISM_MAP = {
+    'H. sapiens (GRCh38)': 'human',
+    'Human (GRCh38)': 'human',
+    'human': 'human',
+    'M. musculus (GRCm38 / mm10)': 'mouse',
+    'Mouse (GRCm39)': 'mouse',
+    'mouse': 'mouse',
+    'D. melanogaster (dm6)': 'drosophila',
+    'drosophila': 'drosophila',
+    'D. rerio (GRCz11)': 'zebrafish',
+    'zebrafish': 'zebrafish',
+    'Aedes_aegypti': 'aaegypti',
+    'A. aegypti (AaegL5)': 'aaegypti',
+    'Anopheles_gambiae': 'agambiae',
+    'A. gambiae (AgamP4)': 'agambiae',
+    'Caenorhabditis_elegans': 'worm',
+    'C. elegans (WS285)': 'worm',
+    'Rhodnius_prolixus': 'chagas',
+    'R. prolixus (RproC3)': 'chagas',
+    'G. gallus (GRCg7b)': 'chicken',
+    'chicken': 'chicken'
+}
+
+
 def createPath(config, group, project, organism, libraryType, tuples):
     """Ensures that the output path exists, creates it otherwise, and return where it is"""
     if tuples[0][3]:
@@ -22,9 +50,15 @@ def createPath(config, group, project, organism, libraryType, tuples):
                                                             BRB.misc.pacifier(project))
     os.makedirs(baseDir, mode=0o700, exist_ok=True)
 
-    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), organism.split(' ')[0].lower()))
+    try:
+        simple_organism = ORGANISM_MAP[organism]
+    except KeyError:
+        raise RuntimeError(f"Organism '{organism}' not found in ORGANISM_MAP")
+
+    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), simple_organism))
     os.makedirs(oDir, mode=0o700, exist_ok=True)
     return oDir
+
 
 
 def linkFiles(config, group, project, odir, tuples):

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -475,11 +475,20 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
 
     org = organism2Org(config, organism)
     if (
-        tuples[0][2] == 'Chromium_NextGEM_SingleCell3Prime_GeneExpression_v3.1_DualIndex'
+        tuples[0][2] in (
+            'Chromium_NextGEM_SingleCell3Prime_GeneExpression_v3.1_DualIndex',
+            'Chromium_GEM-X_SingleCell_3primeRNA-seq_v4'
+            )
     ):
         PE = linkFiles(config, group, project, outputDir, tuples)
         # scRNA has their own organism mapping table, just make sure no spaces are included
-        CMD = [config.get('10x', 'RNA'), outputDir, outputDir, organism.split(' ')[0].lower()]
+        # And, we have new organism names, so...
+        try:
+            simple_organism = ORGANISM_MAP[organism]
+        except KeyError:
+            raise RuntimeError(f"Organism '{organism}' not found in ORGANISM_MAP")
+        CMD = [config.get('10x', 'RNA'), outputDir, outputDir, simple_organism]
+]
         log.info(f"scRNA wf CMD: {' '.join(CMD)}")
         try:
             subprocess.check_call(' '.join(CMD), shell=True)

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -8,32 +8,28 @@ from BRB.logger import log
 import stat
 from pathlib import Path
 
-
 # This is an interim solution. Ultimately, validOrganisms and organismNames,
 # or their mappings to human-readable strings,
 # should all be handled in a single database table.
 ORGANISM_MAP = {
     'H. sapiens (GRCh38)': 'human',
     'Human (GRCh38)': 'human',
-    'human': 'human',
     'M. musculus (GRCm38 / mm10)': 'mouse',
     'Mouse (GRCm39)': 'mouse',
-    'mouse': 'mouse',
     'D. melanogaster (dm6)': 'drosophila',
-    'drosophila': 'drosophila',
     'D. rerio (GRCz11)': 'zebrafish',
-    'zebrafish': 'zebrafish',
-    'Aedes_aegypti': 'aaegypti',
-    'A. aegypti (AaegL5)': 'aaegypti',
-    'Anopheles_gambiae': 'agambiae',
-    'A. gambiae (AgamP4)': 'agambiae',
-    'Caenorhabditis_elegans': 'worm',
-    'C. elegans (WS285)': 'worm',
-    'Rhodnius_prolixus': 'chagas',
-    'R. prolixus (RproC3)': 'chagas',
     'G. gallus (GRCg7b)': 'chicken',
-    'chicken': 'chicken'
 }
+
+# Are we supporting these? What are their mappings?
+    # 'Aedes_aegypti': '?',
+    # 'A. aegypti (AaegL5)': '?',
+    # 'Anopheles_gambiae': '?', 
+    # 'A. gambiae (AgamP4)': '?',
+    # 'Caenorhabditis_elegans': '?',
+    # 'C. elegans (WS285)': '?',
+    # 'Rhodnius_prolixus': '?',
+    # 'R. prolixus (RproC3)': '?',
 
 
 def createPath(config, group, project, organism, libraryType, tuples):
@@ -50,15 +46,9 @@ def createPath(config, group, project, organism, libraryType, tuples):
                                                             BRB.misc.pacifier(project))
     os.makedirs(baseDir, mode=0o700, exist_ok=True)
 
-    try:
-        simple_organism = ORGANISM_MAP[organism]
-    except KeyError:
-        raise RuntimeError(f"Organism '{organism}' not found in ORGANISM_MAP")
-
-    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), simple_organism))
+    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), organism.split(' ')[0].lower()))
     os.makedirs(oDir, mode=0o700, exist_ok=True)
     return oDir
-
 
 
 def linkFiles(config, group, project, odir, tuples):
@@ -662,6 +652,7 @@ def GetResults(config, project, libraries):
     external_skipList = []
     for library, v in libraries.items():
         sampleName, libraryType, libraryProtocol, organism, indexType, requestDepth = v
+        organism = ORGANISM_MAP.get(organism, organism)
         # Extra checks to see where we miss out
         if libraryType in validLibraryTypes:
             log.info(f"ValidLibraryType = {libraryType}")

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -19,17 +19,11 @@ ORGANISM_MAP = {
     'D. melanogaster (dm6)': 'drosophila',
     'D. rerio (GRCz11)': 'zebrafish',
     'G. gallus (GRCg7b)': 'chicken',
+    'A. aegypti (AaegL5)': 'Aedes_aegypti',
+    'A. gambiae (AgamP4)': 'Anopheles_gambiae',
+    'C. elegans (WS285)': 'Caenorhabditis_elegans',
+    'R. prolixus (RproC3)': 'Rhodnius_prolixus',
 }
-
-# Are we supporting these? What are their mappings?
-    # 'Aedes_aegypti': '?',
-    # 'A. aegypti (AaegL5)': '?',
-    # 'Anopheles_gambiae': '?', 
-    # 'A. gambiae (AgamP4)': '?',
-    # 'Caenorhabditis_elegans': '?',
-    # 'C. elegans (WS285)': '?',
-    # 'Rhodnius_prolixus': '?',
-    # 'R. prolixus (RproC3)': '?',
 
 
 def createPath(config, group, project, organism, libraryType, tuples):

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -40,7 +40,12 @@ def createPath(config, group, project, organism, libraryType, tuples):
                                                             BRB.misc.pacifier(project))
     os.makedirs(baseDir, mode=0o700, exist_ok=True)
 
-    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), organism.split(' ')[0].lower()))
+    try:
+        simple_organism = ORGANISM_MAP[organism]
+    except KeyError:
+        raise RuntimeError(f"Organism '{organism}' not found in ORGANISM_MAP")
+
+    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), simple_organism))
     os.makedirs(oDir, mode=0o700, exist_ok=True)
     return oDir
 
@@ -646,7 +651,6 @@ def GetResults(config, project, libraries):
     external_skipList = []
     for library, v in libraries.items():
         sampleName, libraryType, libraryProtocol, organism, indexType, requestDepth = v
-        organism = ORGANISM_MAP.get(organism, organism)
         # Extra checks to see where we miss out
         if libraryType in validLibraryTypes:
             log.info(f"ValidLibraryType = {libraryType}")


### PR DESCRIPTION
let's avoid the spaces with this dictionary. We can get rid of it later, I will work on the API endpoint(s) so that we simply go and edit the table on Parkour whenever snakePipes extends and supports other organisms (which is not often, but should anyway be defined in a single place for us)..