### PR TITLE
organism = [org_name, org_label, org_yaml]

### DIFF
--- a/BRB/ET.py
+++ b/BRB/ET.py
@@ -37,6 +37,9 @@ def getOffSpeciesRate(d, organism = None) -> float:
     """
     fname = glob.glob("{}/*rep".format(d))[0]
     # match parkour org to kraken db organism/group
+
+    # TODO: we needed a 4th string <!> I'm just passing org_name and rely on this mapping...
+    # FIXME: BRB.ET.*() calls @ PushButton where the org_name is passed.
     org_map = {
         'Human (GRCh38)': 'humangrp',
         'Human (GRCh37 / hg19)': 'humangrp',

--- a/BRB/ET.py
+++ b/BRB/ET.py
@@ -37,9 +37,6 @@ def getOffSpeciesRate(d, organism = None) -> float:
     """
     fname = glob.glob("{}/*rep".format(d))[0]
     # match parkour org to kraken db organism/group
-
-    # TODO: we needed a 4th string <!> I'm just passing org_name and rely on this mapping...
-    # FIXME: BRB.ET.*() calls @ PushButton where the org_name is passed.
     org_map = {
         'Human (GRCh38)': 'humangrp',
         'Human (GRCh37 / hg19)': 'humangrp',

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -216,7 +216,7 @@ def RNA(config, group, project, organism, libraryType, tuples):
         CMD.extend(['--libraryType', '0'])
     elif tuples[0][2].startswith("NEBNext Low Input RNA Library"):
         # Unstranded
-        CMD.extend(['--libraryType', '0'])
+        CMD.extend(['--libraryType', '0', r"--trimmerOptions '-a AGATCGGAAGAGC -A AGATCGGAAGAGC'"])
     log.info(f"RNA wf CMD: {CMD}")
     try:
         subprocess.check_call(' '.join(CMD), shell=True)

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -445,8 +445,6 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
     ]
     if tuples[0][2] in accepted_names:
         PE = linkFiles(config, group, project, outputDir, tuples)
-        # scRNA has their own organism mapping table, just make sure no spaces are included
-        # FIXME: ^^^ this
         CMD = [config.get('10x', 'RNA'), outputDir, outputDir, org_yaml]
         log.info(f"scRNA wf CMD: {' '.join(CMD)}")
         try:
@@ -631,9 +629,6 @@ def GetResults(config, project, libraries):
             pipeline = pipelines[idx]
             if pipeline not in analysisTypes:
                 analysisTypes[pipeline] = dict()
-            # TODO: iirc labels don't have the unique constrain on our DB,
-            # and using org_yaml (which can be a path) feels awkward here, even if it works.
-            # I can make labels unique and add this constraint, no problem.
             if org_label not in analysisTypes[pipeline]:
                 analysisTypes[pipeline][org_label] = dict()
             if libraryType not in analysisTypes[pipeline][org_label]:


### PR DESCRIPTION
Basically, we pass the list of 3 strings to any pipeline function (e.g. `ATAC()`), and use org_name for logs or emails, org_label for directories, and org_yaml for commands.

Extra maps (`BRB.ET.getOffSpeciesRate()` and `10X_snakepipe`) are not changed (yet). I hope we don't need more strings for these. In any case, I would leave those changes for a latter release.