### PR TITLE
feat: built-in Levenshtein distance

### DIFF
--- a/BRB/demultiplex_relacs.py
+++ b/BRB/demultiplex_relacs.py
@@ -7,7 +7,7 @@ from multiprocessing import Pool
 import subprocess
 import matplotlib.pyplot as plt
 import numpy as np
-from BRB import editdistance as ed
+import BRB.editdistance as ed
 from rich import print
 
 def parseArgs(args=None):

--- a/BRB/demultiplex_relacs.py
+++ b/BRB/demultiplex_relacs.py
@@ -7,7 +7,7 @@ from multiprocessing import Pool
 import subprocess
 import matplotlib.pyplot as plt
 import numpy as np
-import editdistance as ed
+from BRB import editdistance as ed
 from rich import print
 
 def parseArgs(args=None):

--- a/BRB/editdistance.py
+++ b/BRB/editdistance.py
@@ -1,0 +1,36 @@
+def edit_distance(a: str, b: str, max_dist: int | None = None) -> int:
+    if a == b:
+        return 0
+
+    la = len(a)
+    lb = len(b)
+    if max_dist is not None and abs(la - lb) > max_dist:
+        return max_dist + 1
+
+    if la < lb:
+        a, b = b, a
+        la, lb = lb, la
+
+    previous = list(range(lb + 1))
+    for i in range(1, la + 1):
+        current = [i] + [0] * lb
+        best = current[0]
+        ai = a[i - 1]
+        for j in range(1, lb + 1):
+            cost = 0 if ai == b[j - 1] else 1
+            current[j] = min(
+                previous[j] + 1,
+                current[j - 1] + 1,
+                previous[j - 1] + cost,
+            )
+            if current[j] < best:
+                best = current[j]
+        if max_dist is not None and best > max_dist:
+            return max_dist + 1
+        previous = current
+
+    return previous[lb]
+
+
+def eval(a: str, b: str, max_dist: int | None = None) -> int:
+    return edit_distance(a, b, max_dist=max_dist)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ cd BigRedButton
 pip install .
 ```
 
+> [!NOTE]
+> If you get `LookupError: setuptools-scm was unable to detect version`. Ensure that git is available on the conda environment you've just activated: `conda install git`.
+
 Additional tools
 
 1. BRB expects snakePipes is already installed and defined in the config file
 2. In adition, it expects the [10X_snakepipe repository](https://github.com/maxplanck-ie/10X_snakepipe) also defined in the config file
+

--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ pip install .
 Additional tools
 
 1. BRB expects snakePipes is already installed and defined in the config file
-2. In adition, it expects the [10X_snakepipe repository](https://github.com/maxplanck-ie/10X_snakepipe) also defined in the config file
+2. In addition, it expects the [10X_snakepipe repository](https://github.com/maxplanck-ie/10X_snakepipe) also defined in the config file
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">= 3.10"
 dependencies = [
   "bioblend >= 1.2",
   "configparser >= 5.3",
-  "editdistance >= 0.6",
   "matplotlib >= 3.8",
   "numpy >= 1.26",
   "python-dateutil >= 2.8",

--- a/tests/test_editdistance.py
+++ b/tests/test_editdistance.py
@@ -1,0 +1,27 @@
+import pytest
+
+from BRB.editdistance import edit_distance, eval as editdistance_eval
+
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("", "", 0),
+        ("abc", "abc", 0),
+        ("abc", "ab", 1),
+        ("kitten", "sitting", 3),
+        ("GATTACA", "GCATGCU", 4),
+    ],
+)
+def test_edit_distance(a, b, expected):
+    assert edit_distance(a, b) == expected
+    assert editdistance_eval(a, b) == expected
+
+
+def test_edit_distance_is_symmetric():
+    assert edit_distance("barcode", "barc0de") == edit_distance("barc0de", "barcode")
+
+
+def test_edit_distance_max_dist_short_circuits():
+    assert edit_distance("abc", "xyz", max_dist=1) == 2
+    assert edit_distance("abc", "ab", max_dist=1) == 1


### PR DESCRIPTION
removed dependency to a library that is still available on pypi but the repo is archived by owner, so rather keep it lightweight on our side (else: pip is compiling this dependency locally when installing BRB.)