### PR TITLE
ci: apply ruff-format across codebase, add pre-commit hooks, and pin GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,14 @@
 name: Ruff
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: chartboost/ruff-action@e18ae971ccee1b2d7bbef113930f00c670b78da4 # v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,14 +1,20 @@
 name: test
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   pip:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
-    - run: | 
+    - run: |
         pip install .
         pytest

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE }}
           release-type: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        types: [python]
+      - id: end-of-file-fixer
+        types: [python]
+      - id: check-merge-conflict
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.7
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.27.0
+    hooks:
+      - id: zizmor

--- a/BRB/ET.py
+++ b/BRB/ET.py
@@ -8,6 +8,7 @@ from BRB.logger import log
 import pandas as pd
 from pathlib import Path
 
+
 def getNReads(d):
     """
     Get the number of reads and % optical dupes from a directory
@@ -17,39 +18,42 @@ def getNReads(d):
         s = open(fname).read()
         optDupes, total = s.split()
         try:
-            opt_frac = 100. * float(optDupes) / float(total)
+            opt_frac = 100.0 * float(optDupes) / float(total)
         except ZeroDivisionError:
             opt_frac = float(-1)
         return int(total) - int(optDupes), opt_frac
     else:
         # For machines in which we don't mark duplicates
         # Just count the number of reads in R1
-        CMD1 = ["zcat", glob.glob("{}/*_R1.fastq.gz".format(d.replace("FASTQC_", "")))[0]]
+        CMD1 = [
+            "zcat",
+            glob.glob("{}/*_R1.fastq.gz".format(d.replace("FASTQC_", "")))[0],
+        ]
         CMD2 = ["wc", "-l"]
         c1 = subprocess.Popen(CMD1, stdout=subprocess.PIPE)
         res = subprocess.check_output(CMD2, stdin=c1.stdout)
-        return (int(res) / 4), 0.
+        return (int(res) / 4), 0.0
 
 
-def getOffSpeciesRate(d, organism = None) -> float:
+def getOffSpeciesRate(d, organism=None) -> float:
     """
     Parses kraken report for number of reads mapping to unexpected organisms
     """
     fname = glob.glob("{}/*rep".format(d))[0]
     # match parkour org to kraken db organism/group
     org_map = {
-        'Human (GRCh38)': 'humangrp',
-        'Human (GRCh37 / hg19)': 'humangrp',
-        'Mouse (GRCm38 / mm10)': 'mousegrp',
-        'Mouse (GRCm39)': 'mousegrp',
-        'mouse': 'mousegrp',
-        'human': 'humangrp',
-        'Escherichia phage Lambda':'lambdaphage',
-        'Caenorhabditis_elegans': 'c-elegans',
-        'lamprey': 'sea-lamprey',
-        'medaka': 'japanese-medaka',
-        'zebrafish': 'zebrafish',
-        'drosophila': 'flygrp',
+        "Human (GRCh38)": "humangrp",
+        "Human (GRCh37 / hg19)": "humangrp",
+        "Mouse (GRCm38 / mm10)": "mousegrp",
+        "Mouse (GRCm39)": "mousegrp",
+        "mouse": "mousegrp",
+        "human": "humangrp",
+        "Escherichia phage Lambda": "lambdaphage",
+        "Caenorhabditis_elegans": "c-elegans",
+        "lamprey": "sea-lamprey",
+        "medaka": "japanese-medaka",
+        "zebrafish": "zebrafish",
+        "drosophila": "flygrp",
     }
     if organism not in org_map:
         log.info(f"getOffSpeciesRate - organism {organism} is not in the org_map!")
@@ -57,14 +61,14 @@ def getOffSpeciesRate(d, organism = None) -> float:
     with open(fname) as f:
         for line in f:
             if org_map[organism] in line:
-                off = 1-(float(line.strip().split()[0])/100)
+                off = 1 - (float(line.strip().split()[0]) / 100)
     # off-species actually means fraction of non-expected organism reads !
     # off-species reads vs of-species reads ;)
     log.info(f"confident reads for {fname} = {off}")
     return off
 
 
-def getBaseStatistics(config, outputDir, samples_id, organism = None):
+def getBaseStatistics(config, outputDir, samples_id, organism=None):
     """
     Return a directionary with keys lib names and values:
     (sample name, nReads, off-species rate, % optical dupes)
@@ -76,16 +80,21 @@ def getBaseStatistics(config, outputDir, samples_id, organism = None):
     odir, adir = os.path.split(os.path.split(outputDir)[0])
     pdir = "FASTQC_Project_{}".format(adir[9:])
     for sample in samples_id:
-        for d in glob.glob("{}/{}/{}/Sample_{}".format(config.get('Paths','baseData'),
-                                                       config.get('Options', 'runID'),
-                                                       pdir, sample)):
+        for d in glob.glob(
+            "{}/{}/{}/Sample_{}".format(
+                config.get("Paths", "baseData"),
+                config.get("Options", "runID"),
+                pdir,
+                sample,
+            )
+        ):
             libName = os.path.split(d)[1][7:]
             if len(glob.glob("{}/*_R1_fastqc.zip".format(d))) == 0:
                 continue  # Skip failed samples
             sampleName = glob.glob("{}/*_R1_fastqc.zip".format(d))[0]
             sampleName = os.path.split(sampleName)[1][:-14]
-            nReads, optDupes = getNReads(d) # opt. dup.
-            offRate = getOffSpeciesRate(d,organism)
+            nReads, optDupes = getNReads(d)  # opt. dup.
+            offRate = getOffSpeciesRate(d, organism)
             baseDict[libName] = [sampleName, nReads, offRate, optDupes]
             s2l[sampleName] = libName
     return baseDict, s2l
@@ -98,20 +107,24 @@ def DNA(config, outputDir, baseDict, sample2lib):
     Add % mapped, % dupped, and insert size to baseDict. Filter it for those actually in the output
     """
     # baseDict, sample2lib = getBaseStatistics(config, outputDir)
-    # If we have RELACS, the sample2lib won't match what we find here. 
+    # If we have RELACS, the sample2lib won't match what we find here.
     # We can re-parse the sampleSheet to upload actual statistics of the RELACS demuxed samples.
-    if Path(outputDir, 'RELACS_sampleSheet.txt').exists():
+    if Path(outputDir, "RELACS_sampleSheet.txt").exists():
         # RELACS is a problem for parkour (matching is in sampleID / barcode level).
         # Just return a list of dicts with the previous info
         m = []
         for k, v in baseDict.items():
-            m.append({'barcode': k,
-                    'reads_pf_sequenced': v[1],
-                    'confident_reads': v[2],
-                    'optical_duplicates': v[3]})
+            m.append(
+                {
+                    "barcode": k,
+                    "reads_pf_sequenced": v[1],
+                    "confident_reads": v[2],
+                    "optical_duplicates": v[3],
+                }
+            )
         log.info(f"ET - DNA module detected RELACS. Returning {m}")
         return m
-        
+
     # % Mapped
     for fname in glob.glob("{}/Bowtie2/*.Bowtie2_summary.txt".format(outputDir)):
         sampleName = os.path.basename(fname).split(".Bowtie2_summary")[0]
@@ -119,22 +132,33 @@ def DNA(config, outputDir, baseDict, sample2lib):
         mappedPercent = lastLine.split("%")[0]
         baseDict[sample2lib[sampleName]].append(float(mappedPercent))
         # % Duplicated
-        dup_info = glob.glob("{}/multiQC/multiqc_data/multiqc_samtools_flagstat.txt".format(outputDir))[0]
-        dup_df = pd.read_csv(dup_info, sep ="\t", usecols=["Sample", "total_passed", "duplicates_passed"])
+        dup_info = glob.glob(
+            "{}/multiQC/multiqc_data/multiqc_samtools_flagstat.txt".format(outputDir)
+        )[0]
+        dup_df = pd.read_csv(
+            dup_info, sep="\t", usecols=["Sample", "total_passed", "duplicates_passed"]
+        )
 
         # Following condition handle sample-name mismatches caused by trailing '_' or any other sign in parsed filenames
         # Assign "0 (zero)" if the sample is not present in dup_df.
         if sampleName not in list(dup_df["Sample"].astype(str)):
-            dup_rate= 0
+            dup_rate = 0
         else:
             dup_df = dup_df.loc[dup_df["Sample"].astype(str) == sampleName]
-            dup_rate = dup_df["duplicates_passed"].values/dup_df["total_passed"].values*100
+            dup_rate = (
+                dup_df["duplicates_passed"].values / dup_df["total_passed"].values * 100
+            )
             dup_rate = dup_rate[0]
         baseDict[sample2lib[sampleName]].append(dup_rate)
         # Median insert size
-        insert_size_info = os.path.join(outputDir, "deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv")
-        insert_size_df = pd.read_csv(insert_size_info, sep ="\t")
-        medInsertSize = insert_size_df.loc[insert_size_df["Unnamed: 0"]=="filtered_bam/"+sampleName+".filtered.bam"]
+        insert_size_info = os.path.join(
+            outputDir, "deepTools_qc/bamPEFragmentSize/fragmentSize.metric.tsv"
+        )
+        insert_size_df = pd.read_csv(insert_size_info, sep="\t")
+        medInsertSize = insert_size_df.loc[
+            insert_size_df["Unnamed: 0"]
+            == "filtered_bam/" + sampleName + ".filtered.bam"
+        ]
         medInsertSize = medInsertSize["Frag. Len. Median"].values[0]
         baseDict[sample2lib[sampleName]].append(int(medInsertSize))
 
@@ -143,13 +167,17 @@ def DNA(config, outputDir, baseDict, sample2lib):
     # Reformat into a matrix
     m = []
     for k, v in baseDict.items():
-        m.append({'barcode': k,
-                  'reads_pf_sequenced': v[1],
-                  'confident_reads': v[2],
-                  'optical_duplicates': v[3],
-                  'dupped_reads': v[5],
-                  'mapped_reads': v[4],
-                  'insert_size': v[6]})
+        m.append(
+            {
+                "barcode": k,
+                "reads_pf_sequenced": v[1],
+                "confident_reads": v[2],
+                "optical_duplicates": v[3],
+                "dupped_reads": v[5],
+                "mapped_reads": v[4],
+                "insert_size": v[6],
+            }
+        )
     return m
 
 
@@ -166,10 +194,10 @@ def RNA(config, outputDir, baseDict, sample2lib):
         uniq = 0
         multimap = 0
         for line in f:
-            if 'Uniquely mapped reads %' in line:
+            if "Uniquely mapped reads %" in line:
                 uniq = float(line.strip().split("\t")[-1][:-1])
                 tot += uniq
-            elif '% of reads mapped to multiple loci' in line:
+            elif "% of reads mapped to multiple loci" in line:
                 multimap = float(line.strip().split("\t")[-1][:-1])
                 tot += multimap
         sampleName = os.path.basename(fname).split(".")[0]
@@ -177,58 +205,80 @@ def RNA(config, outputDir, baseDict, sample2lib):
         baseDict[sample2lib[sampleName]].append(uniq)
         baseDict[sample2lib[sampleName]].append(multimap)
         #  duplication
-        dup_info = glob.glob("{}/multiQC/multiqc_data/multiqc_samtools_flagstat.txt".format(outputDir))[0]
-        dup_df = pd.read_csv(dup_info, sep ="\t", usecols=["Sample", "total_passed", "duplicates_passed"])
+        dup_info = glob.glob(
+            "{}/multiQC/multiqc_data/multiqc_samtools_flagstat.txt".format(outputDir)
+        )[0]
+        dup_df = pd.read_csv(
+            dup_info, sep="\t", usecols=["Sample", "total_passed", "duplicates_passed"]
+        )
         dup_df = dup_df.loc[dup_df["Sample"].astype(str) == sampleName]
-        dup_rate = dup_df["duplicates_passed"].values/dup_df["total_passed"].values*100
+        dup_rate = (
+            dup_df["duplicates_passed"].values / dup_df["total_passed"].values * 100
+        )
         dup_rate = dup_rate[0]
         baseDict[sample2lib[sampleName]].append(dup_rate)
         # assigned reads
-        assigned_info = glob.glob("{}/multiQC/multiqc_data/multiqc_featurecounts.txt".format(outputDir))[0]
-        assigned_df = pd.read_csv(assigned_info, sep ="\t", usecols=["Sample", "Total", "Assigned"])
-        assigned_df = assigned_df.loc[assigned_df["Sample"].astype(str) == sampleName+".filtered"]
-        assigned_rate = assigned_df["Assigned"].values/assigned_df["Total"].values*100
+        assigned_info = glob.glob(
+            "{}/multiQC/multiqc_data/multiqc_featurecounts.txt".format(outputDir)
+        )[0]
+        assigned_df = pd.read_csv(
+            assigned_info, sep="\t", usecols=["Sample", "Total", "Assigned"]
+        )
+        assigned_df = assigned_df.loc[
+            assigned_df["Sample"].astype(str) == sampleName + ".filtered"
+        ]
+        assigned_rate = (
+            assigned_df["Assigned"].values / assigned_df["Total"].values * 100
+        )
         assigned_rate = assigned_rate[0]
         baseDict[sample2lib[sampleName]].append(assigned_rate)
-
 
     log.info(f"ET - RNA module parsed {baseDict}")
     # Reformat into a matrix
     m = []
     for k, v in baseDict.items():
-        m.append({'barcode': k,
-                  'reads_pf_sequenced': v[1],
-                  'confident_reads': v[2],
-                  'optical_duplicates': v[3],
-                  'mapped_reads': v[4],
-                  'uniq_mapped': v[5],
-                  'multi_mapped': v[6],
-                  'dupped_reads': v[7],
-                  'assigned_reads': v[8]})
+        m.append(
+            {
+                "barcode": k,
+                "reads_pf_sequenced": v[1],
+                "confident_reads": v[2],
+                "optical_duplicates": v[3],
+                "mapped_reads": v[4],
+                "uniq_mapped": v[5],
+                "multi_mapped": v[6],
+                "dupped_reads": v[7],
+                "assigned_reads": v[8],
+            }
+        )
     return m
 
 
 def sendToParkour(config, msg):
-    basePath= config.get("Paths","baseData")
-    aviti_check= glob.glob(f"{basePath}/*/RunManifest.csv")
+    basePath = config.get("Paths", "baseData")
+    aviti_check = glob.glob(f"{basePath}/*/RunManifest.csv")
     if aviti_check:
         FCID = config.get("Options", "runID").split("_")[2]
-        if '-' in FCID:
-            FCID = FCID.split('-')[-1]
-        d = {'flowcell_id': FCID}
-        d['sequences'] = json.dumps(msg)
+        if "-" in FCID:
+            FCID = FCID.split("-")[-1]
+        d = {"flowcell_id": FCID}
+        d["sequences"] = json.dumps(msg)
     else:
         FCID = config.get("Options", "runID").split("_")[3][1:]
-        if '-' in FCID:
-            FCID = FCID.split('-')[-1]
-        d = {'flowcell_id': FCID}
-        d['sequences'] = json.dumps(msg)
+        if "-" in FCID:
+            FCID = FCID.split("-")[-1]
+        d = {"flowcell_id": FCID}
+        d["sequences"] = json.dumps(msg)
     log.info(f"sendToParkour: Sending {d} to Parkour")
-    res = requests.post(config.get("Parkour", "ResultsURL"), auth=(config.get("Parkour", "user"), config.get("Parkour", "password")), data=d, verify=config.get("Parkour", "cert"))
+    res = requests.post(
+        config.get("Parkour", "ResultsURL"),
+        auth=(config.get("Parkour", "user"), config.get("Parkour", "password")),
+        data=d,
+        verify=config.get("Parkour", "cert"),
+    )
     log.info(f"sendToParkour return {res}")
     return res
-    
-    
+
+
 def phoneHome(config, outputDir, pipeline, samples_tuples, organism, project, libType):
     """
     Return metrics to Parkour, the results are in outputDir and pipeline needs to be run on them
@@ -236,25 +286,29 @@ def phoneHome(config, outputDir, pipeline, samples_tuples, organism, project, li
     samples_id = [row[0] for row in samples_tuples]
     baseDict, sample2lib = getBaseStatistics(config, outputDir, samples_id, organism)
     msg = None
-    if pipeline == 'DNA':
+    if pipeline == "DNA":
         msg = DNA(config, outputDir, baseDict, sample2lib)
-    elif pipeline == 'RNA':
+    elif pipeline == "RNA":
         msg = RNA(config, outputDir, baseDict, sample2lib)
     else:
         m = []
         for k, v in baseDict.items():
-            m.append({'barcode': k,
-                      'reads_pf_sequenced': v[1],
-                      'confident_reads': v[2],
-                      'optical_duplicates': v[3]})
+            m.append(
+                {
+                    "barcode": k,
+                    "reads_pf_sequenced": v[1],
+                    "confident_reads": v[2],
+                    "optical_duplicates": v[3],
+                }
+            )
         msg = m
     log.info(f"phoneHome: got msg = {msg}")
     if msg is not None:
         ret = sendToParkour(config, msg)
     else:
         ret = None
-    
-    return [project, organism, libType, pipeline, 'success', ret]
+
+    return [project, organism, libType, pipeline, "success", ret]
 
 
 def telegraphHome(config, group, project, skipList, organism=None):
@@ -266,11 +320,11 @@ def telegraphHome(config, group, project, skipList, organism=None):
     log.info(f"telegraphHome triggered for {project}")
     # make a fake output directory path
     baseDir = Path(
-        config.get('Paths', 'groupData'),
+        config.get("Paths", "groupData"),
         BRB.misc.pacifier(group),
-        BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-        config.get('Options', 'runID'),
-        BRB.misc.pacifier(project)
+        BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+        config.get("Options", "runID"),
+        BRB.misc.pacifier(project),
     )
     # Mock path
     outputDir = baseDir / "DNA_mouse"
@@ -279,12 +333,16 @@ def telegraphHome(config, group, project, skipList, organism=None):
     # Reformat into a matrix
     m = []
     for k, v in baseDict.items():
-        m.append({'barcode': k,
-                  'reads_pf_sequenced': v[1],
-                  'confident_reads': v[2],
-                  'optical_duplicates': v[3]})
+        m.append(
+            {
+                "barcode": k,
+                "reads_pf_sequenced": v[1],
+                "confident_reads": v[2],
+                "optical_duplicates": v[3],
+            }
+        )
     ret = sendToParkour(config, m)
     # Format the libtypes
-    libTypes = ','.join(set([i[2] for i in skipList]))
+    libTypes = ",".join(set([i[2] for i in skipList]))
     # [project, organism, libtypes, workflow, workflow status, parkour status, sambaUpdate]
     return [project, organism, libTypes, None, None, ret, False]

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -12,17 +12,23 @@ from pathlib import Path
 def createPath(config, group, project, org_label, libraryType, tuples):
     """Ensures that the output path exists, creates it otherwise, and return where it is"""
     if tuples[0][3]:
-        baseDir = "{}/{}/Analysis_{}".format(config.get('Paths', 'baseData'),
-                                                            config.get('Options', 'runID'),
-                                                            BRB.misc.pacifier(project))
+        baseDir = "{}/{}/Analysis_{}".format(
+            config.get("Paths", "baseData"),
+            config.get("Options", "runID"),
+            BRB.misc.pacifier(project),
+        )
     else:
-        baseDir = "{}/{}/{}/{}/Analysis_{}".format(config.get('Paths', 'groupData'),
-                                                            BRB.misc.pacifier(group),
-                                                            BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                            config.get('Options', 'runID'),
-                                                            BRB.misc.pacifier(project))
+        baseDir = "{}/{}/{}/{}/Analysis_{}".format(
+            config.get("Paths", "groupData"),
+            BRB.misc.pacifier(group),
+            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+            config.get("Options", "runID"),
+            BRB.misc.pacifier(project),
+        )
     os.makedirs(baseDir, mode=0o700, exist_ok=True)
-    oDir = os.path.join(baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), org_label))
+    oDir = os.path.join(
+        baseDir, "{}_{}".format(BRB.misc.pacifier(libraryType), org_label)
+    )
     os.makedirs(oDir, mode=0o700, exist_ok=True)
     return oDir
 
@@ -30,23 +36,31 @@ def createPath(config, group, project, org_label, libraryType, tuples):
 def linkFiles(config, group, project, odir, tuples):
     """Create symlinks in odir to fastq files in {project}. Return 1 if paired-end, 0 otherwise."""
     if tuples[0][3]:
-        baseDir = "{}/{}/Project_{}".format(config.get('Paths', 'baseData'),
-                                                            config.get('Options', 'runID'),
-                                                            BRB.misc.pacifier(project))
+        baseDir = "{}/{}/Project_{}".format(
+            config.get("Paths", "baseData"),
+            config.get("Options", "runID"),
+            BRB.misc.pacifier(project),
+        )
     else:
-        baseDir = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
-                                                           BRB.misc.pacifier(group),
-                                                           BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                           config.get('Options', 'runID'),
-                                                           BRB.misc.pacifier(project))
+        baseDir = "{}/{}/{}/{}/Project_{}".format(
+            config.get("Paths", "groupData"),
+            BRB.misc.pacifier(group),
+            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+            config.get("Options", "runID"),
+            BRB.misc.pacifier(project),
+        )
     PE = False
     for t in tuples:
-        currentName = "{}/{}_R1.fastq.gz".format(os.path.join(baseDir, "Sample_{}".format(t[0])), t[1])
+        currentName = "{}/{}_R1.fastq.gz".format(
+            os.path.join(baseDir, "Sample_{}".format(t[0])), t[1]
+        )
         newName = "{}/{}_R1.fastq.gz".format(odir, t[1])
         if os.path.exists(currentName):
             if not os.path.exists(newName):
                 os.symlink(currentName, newName)
-        currentName = "{}/{}_R2.fastq.gz".format(os.path.join(baseDir, "Sample_{}".format(t[0])), t[1])
+        currentName = "{}/{}_R2.fastq.gz".format(
+            os.path.join(baseDir, "Sample_{}".format(t[0])), t[1]
+        )
         newName = "{}/{}_R2.fastq.gz".format(odir, t[1])
         if os.path.exists(currentName):
             if not os.path.exists(newName):
@@ -76,82 +90,90 @@ def relinkFiles(config, group, project, org_label, libraryType, tuples):
     odir = os.path.join(outputDir, "originalFASTQ")
     linkFiles(config, group, project, odir, tuples)
     # Copy mqc
-    mqcf = os.path.join(outputDir, 'multiQC', 'multiqc_report.html')
+    mqcf = os.path.join(outputDir, "multiQC", "multiqc_report.html")
     if os.path.exists(mqcf):
         log.info(f"Multiqc report found for {group} project {project}.")
-        oname = 'Analysis' + project + '_multiqc.html'
-        of = Path(config.get('Paths', 'bioinfoCoreDir')) / oname
+        oname = "Analysis" + project + "_multiqc.html"
+        of = Path(config.get("Paths", "bioinfoCoreDir")) / oname
         log.info(f"Trying to copy mqc report to {of}.")
         shutil.copyfile(mqcf, of)
     else:
         log.info(f"no multiqc report under {mqcf}.")
 
 
-def getsambaPath(lane_dir,Sequencer):
+def getsambaPath(lane_dir, Sequencer):
     if Sequencer == "Aviti":
         current_year = str(lane_dir)[0:4]
-        year_postfix = Path("Sequence_Quality_" + current_year) / Path("AVITI24_" + current_year)
+        year_postfix = Path("Sequence_Quality_" + current_year) / Path(
+            "AVITI24_" + current_year
+        )
     else:
         current_year = "20" + str(lane_dir)[0:2]
-        year_postfix = Path("Sequence_Quality_" + current_year) / Path("Illumina_" + current_year)
+        year_postfix = Path("Sequence_Quality_" + current_year) / Path(
+            "Illumina_" + current_year
+        )
     return current_year, year_postfix
 
 
 def copyCellRanger(config, d):
-    '''
+    """
     copy Cellranger web_summaries to sequencing facility lane subdirectory & bioinfocore qc directory.
     e.g. /seqFacDir/Sequence_Quality_yyyy/Illumina_yyyy/flowcell_xxxx_lane_1/Analysis_xxx_sample_web_summary.html
-   
+
           :params config: configuration parsed from .ini file
-          :params d: path to subdirectory of analysis folder, .e.g. 
+          :params d: path to subdirectory of analysis folder, .e.g.
           /data/xxx/sequencing_data/yyyy_lanes_1/Analysis_2526_zzzz/RNA-Seq
           :type config: configparser.ConfigParser
           :type d: str
           :return: None
           :rtype: None
-    '''
+    """
 
-    files = glob.glob(os.path.join(d, '*/outs/', 'web_summary.html'))
-    sequencing_type= config.get("Options", "sequencerType")
-    
-    
+    files = glob.glob(os.path.join(d, "*/outs/", "web_summary.html"))
+    sequencing_type = config.get("Options", "sequencerType")
+
     # /data/xxx/yyyy_lanes_1/Analysis_2526_zzzz/RNA-Seqsinglecell_mouse ->
     # yyyy_lanes_1
     lane_dir = Path(d).parents[1].stem
-    current_year, year_postfix = getsambaPath(lane_dir,sequencing_type)
+    current_year, year_postfix = getsambaPath(lane_dir, sequencing_type)
     for fname in files:
         # to seqfac dir.
-        nname = fname.split('/')
-        nname = "_".join([nname[-5], nname[-3],nname[-1]])
+        nname = fname.split("/")
+        nname = "_".join([nname[-5], nname[-3], nname[-1]])
         # make lane directory in seqFacDir and copy it over
-        seqfac_lane_dir = Path(config.get('Paths', 'seqFacDir')) / year_postfix / lane_dir
+        seqfac_lane_dir = (
+            Path(config.get("Paths", "seqFacDir")) / year_postfix / lane_dir
+        )
         os.makedirs(seqfac_lane_dir, exist_ok=True)
         # Fetch flowcell ID, in case of reseq
-        short_fid = str(os.path.basename(lane_dir)).split('_')[2] + '_'
-        bioinfoCoreDirPath = Path(config.get('Paths', 'bioinfoCoreDir')) / Path(short_fid + nname)
+        short_fid = str(os.path.basename(lane_dir)).split("_")[2] + "_"
+        bioinfoCoreDirPath = Path(config.get("Paths", "bioinfoCoreDir")) / Path(
+            short_fid + nname
+        )
         nname = seqfac_lane_dir / nname
         shutil.copyfile(fname, nname)
         # to bioinfocore dir
         shutil.copyfile(fname, bioinfoCoreDirPath)
-    
 
 
 def copyRELACS(config, d):
-    '''
+    """
     copy RELACS demultiplexing png files to sequencing facility lane subdirectory.
     e.g. /seqFacDir/Sequence_Quality_yyyy/Illumina_yyyy/flowcell_xxxx_lane_1/xxx_RELACS_sample_fig.png
-   
+
           :params config: configuration parsed from .ini file
-          :params d: path to subdirectory of analysis folder, .e.g. 
+          :params d: path to subdirectory of analysis folder, .e.g.
           /data/xxx/sequencing_data/yyyy_lanes_1/Analysis_2526_zzzz/ChIP-Seq_bla/RELACS_demultiplexing
           :type config: configparser.ConfigParser
           :type d: str
           :return: None
           :rtype: None
-    '''
+    """
 
-    files = glob.glob(os.path.join(d, "RELACS_demultiplexing", 'Sample*/', '*_fig.png')) + glob.glob(os.path.join(d, "multiQC", '*html'))
-    sequencing_type=config.get("Options", "sequencerType")
+    files = glob.glob(
+        os.path.join(d, "RELACS_demultiplexing", "Sample*/", "*_fig.png")
+    ) + glob.glob(os.path.join(d, "multiQC", "*html"))
+    sequencing_type = config.get("Options", "sequencerType")
 
     # /data/xxx/yyyy_lanes_1/Analysis_2526_zzzz/ChIP-Seq_mouse/RELACS_demultiplexing ->
     # Sequence_Quality_yyyy/Illumina_yyyy/yyyy_lanes_1
@@ -160,18 +182,20 @@ def copyRELACS(config, d):
     log.info(f"copyRELACS - copying over RELACS files to samba path {year_postfix}")
     for fname in files:
         # to seqfac dir.
-        nname = fname.split('/')
-        if '.html' in fname:
+        nname = fname.split("/")
+        if ".html" in fname:
             # ['', 'data', PI, seqdat, fid, analysis, libtype, multiqc, mqc.html]
-            nname = "_".join([nname[-4], 'RELACS_analysis.html'])
+            nname = "_".join([nname[-4], "RELACS_analysis.html"])
         else:
             # ['', data, PI, seqdat, fid, analysis, libtype, RELACS_demultiplexing, Sample_1, mark_fig.png]
-            nname = "_".join([nname[-5], nname[-3],nname[-1]])
+            nname = "_".join([nname[-5], nname[-3], nname[-1]])
         # make lane directory in seqFacDir and copy it over
-        seqfac_lane_dir = Path(config.get('Paths', 'seqFacDir')) / year_postfix / lane_dir
+        seqfac_lane_dir = (
+            Path(config.get("Paths", "seqFacDir")) / year_postfix / lane_dir
+        )
         os.makedirs(seqfac_lane_dir, exist_ok=True)
         nname = seqfac_lane_dir / nname
-        bname = Path(config.get('Paths', 'bioinfoCoreDir')) / nname
+        bname = Path(config.get("Paths", "bioinfoCoreDir")) / nname
         shutil.copyfile(fname, nname)
         shutil.copyfile(fname, bname)
 
@@ -180,15 +204,15 @@ def tidyUpABit(d):
     """
     Reduce the number of files in the analysis folder.
     """
-    for _d in ['clusters_logs', '.snakemake']:
+    for _d in ["clusters_logs", ".snakemake"]:
         _ = os.path.join(d, _d)
         if os.path.exists(_):
             shutil.rmtree(_)
-    (Path(d) / 'config.yaml').unlink(missing_ok=True)
-    (Path(d) / 'multiQC' / 'multiqc_data' / 'multiqc.log').unlink(missing_ok=True)
-    (Path(d) / 'multiQC' / 'multiQC.out').unlink(missing_ok=True)
-    (Path(d) / 'multiQC' / 'multiQC.err').unlink(missing_ok=True)
-    (Path(d) / 'config.yaml').unlink(missing_ok=True)
+    (Path(d) / "config.yaml").unlink(missing_ok=True)
+    (Path(d) / "multiQC" / "multiqc_data" / "multiqc.log").unlink(missing_ok=True)
+    (Path(d) / "multiQC" / "multiQC.out").unlink(missing_ok=True)
+    (Path(d) / "multiQC" / "multiQC.err").unlink(missing_ok=True)
+    (Path(d) / "config.yaml").unlink(missing_ok=True)
 
 
 def stripRights(d):
@@ -220,17 +244,37 @@ def RNA(config, group, project, organism, libraryType, tuples):
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'mRNAseq', '--DAG', '--trim', '-i', outputDir, '-o', outputDir, org_yaml]
-    if tuples[0][2].startswith("Smart-Seq2")  or tuples[0][2].startswith("NEBNext Single Cell RNA Library Preparation"):
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [
+        CMD,
+        "mRNAseq",
+        "--DAG",
+        "--trim",
+        "-i",
+        outputDir,
+        "-o",
+        outputDir,
+        org_yaml,
+    ]
+    if tuples[0][2].startswith("Smart-Seq2") or tuples[0][2].startswith(
+        "NEBNext Single Cell RNA Library Preparation"
+    ):
         # SMART-seq isn't a dUTP-based method!
-        CMD.extend(['--libraryType', '0'])
+        CMD.extend(["--libraryType", "0"])
     elif tuples[0][2].startswith("NEBNext Low Input RNA Library"):
         # Unstranded
-        CMD.extend(['--libraryType', '0', r"--trimmerOptions '-a AGATCGGAAGAGC -A AGATCGGAAGAGC'"])
+        CMD.extend(
+            [
+                "--libraryType",
+                "0",
+                r"--trimmerOptions '-a AGATCGGAAGAGC -A AGATCGGAAGAGC'",
+            ]
+        )
     log.info(f"RNA wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
@@ -248,46 +292,57 @@ def RELACS(config, group, project, organism, libraryType, tuples):
 
     There better not be any duplicate RELACS sample names!
     """
-    runID = config.get('Options', 'runID').split("_lanes")[0]
-    sequencerType = config.get('Options', 'sequencerType') 
+    runID = config.get("Options", "runID").split("_lanes")[0]
+    sequencerType = config.get("Options", "sequencerType")
     org_name, org_label, org_yaml = organism
-    outputDir = createPath(config, group, BRB.misc.pacifier(project), org_label, libraryType, tuples)
+    outputDir = createPath(
+        config, group, BRB.misc.pacifier(project), org_label, libraryType, tuples
+    )
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, True
 
     project = BRB.misc.pacifier(project)
 
     if sequencerType == "Aviti":
-        matches = glob.glob(f"/dont_touch_this/short_runs/AV*/{runID}/RELACS_Project_{project}.txt")
+        matches = glob.glob(
+            f"/dont_touch_this/short_runs/AV*/{runID}/RELACS_Project_{project}.txt"
+        )
         sampleSheet = matches[0] if matches else None
     else:
-        sampleSheet = f"/dont_touch_this/short_runs/{runID}/RELACS_Project_{project}.txt"
+        sampleSheet = (
+            f"/dont_touch_this/short_runs/{runID}/RELACS_Project_{project}.txt"
+        )
 
     # Fallback if exact path doesn't exist
-    if not os.path.exists(sampleSheet) and not os.path.exists(os.path.join(outputDir, "RELACS_sampleSheet.txt")):
+    if not os.path.exists(sampleSheet) and not os.path.exists(
+        os.path.join(outputDir, "RELACS_sampleSheet.txt")
+    ):
         log.critical("RELACS: wrong samplesheet name: {}".format(sampleSheet))
         return None, 1, False
 
-
-    baseDir = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
-                                                           BRB.misc.pacifier(group),
-                                                           BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                                           config.get('Options', 'runID'),
-                                                           project)
+    baseDir = "{}/{}/{}/{}/Project_{}".format(
+        config.get("Paths", "groupData"),
+        BRB.misc.pacifier(group),
+        BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+        config.get("Options", "runID"),
+        project,
+    )
 
     # Link in files
     if not os.path.exists(os.path.join(outputDir, "RELACS_sampleSheet.txt")):
         shutil.copyfile(sampleSheet, os.path.join(outputDir, "RELACS_sampleSheet.txt"))
-    
+
     # Only re-run RELACS demultiplexing if we don't have png files generated for every sample (pre-demux)
     # Infer number of samples from relacs samplesheet.
     premuxSamples = []
     with open(os.path.join(outputDir, "RELACS_sampleSheet.txt")) as f:
         for line in f:
-            _s = line.strip().split('\t')[0]
+            _s = line.strip().split("\t")[0]
             if _s not in premuxSamples:
                 premuxSamples.append(_s)
-    if len(premuxSamples) != len(list((Path(outputDir) / 'RELACS_demultiplexing').rglob("*png"))):
+    if len(premuxSamples) != len(
+        list((Path(outputDir) / "RELACS_demultiplexing").rglob("*png"))
+    ):
         unlinkDirs = []
         for d in glob.glob("{}/Sample_*".format(baseDir)):
             bname = os.path.basename(d)
@@ -297,10 +352,18 @@ def RELACS(config, group, project, organism, libraryType, tuples):
                 os.symlink(d, newName)
 
         # -p 10 is pretty much arbitrary
-        CMD = ["demultiplex_relacs", "--umiLength", "4", "-p", "10", os.path.join(outputDir, "RELACS_sampleSheet.txt"), os.path.join(outputDir, "RELACS_demultiplexing")]
+        CMD = [
+            "demultiplex_relacs",
+            "--umiLength",
+            "4",
+            "-p",
+            "10",
+            os.path.join(outputDir, "RELACS_sampleSheet.txt"),
+            os.path.join(outputDir, "RELACS_demultiplexing"),
+        ]
         log.info(f"RELACS demux wf CMD: {CMD}")
         try:
-            subprocess.check_call(' '.join(CMD), shell=True, cwd=outputDir)
+            subprocess.check_call(" ".join(CMD), shell=True, cwd=outputDir)
         except:
             return outputDir, 1, False
 
@@ -309,33 +372,52 @@ def RELACS(config, group, project, organism, libraryType, tuples):
             os.unlink(d)
 
     # Link in the RELACS demultiplexed files
-    for fname in glob.glob(os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")):
+    for fname in glob.glob(
+        os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")
+    ):
         bname = os.path.basename(fname)
-        if 'unknown' not in bname:
+        if "unknown" not in bname:
             newName = os.path.join(outputDir, bname)
             if not os.path.exists(newName):
                 os.symlink(fname, newName)
 
-
     # Back to the normal DNA pipeline
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'DNAmapping', '--DAG', '--trim', r"--trimmerOptions '-a AGATCGGAAGAG -A AGATCGGAAGAG'", '--UMIDedup', '--mapq', '3', '-i', outputDir, '-o', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [
+        CMD,
+        "DNAmapping",
+        "--DAG",
+        "--trim",
+        r"--trimmerOptions '-a AGATCGGAAGAG -A AGATCGGAAGAG'",
+        "--UMIDedup",
+        "--mapq",
+        "3",
+        "-i",
+        outputDir,
+        "-o",
+        outputDir,
+        org_yaml,
+    ]
     log.info(f"RELACS DNA wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
     tidyUpABit(outputDir)
     copyRELACS(config, outputDir)
     # Recreate links under originalFastQ
-    for fname in glob.glob(os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")):
+    for fname in glob.glob(
+        os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")
+    ):
         bname = os.path.basename(fname)
-        if bname.startswith('unknown'):
+        if bname.startswith("unknown"):
             continue
-        if not os.path.exists(os.path.join(outputDir, 'originalFASTQ')):
-            os.mkdir(os.path.join(outputDir, 'originalFASTQ'))
-        newName = os.path.join(outputDir, 'originalFASTQ', bname)
+        if not os.path.exists(os.path.join(outputDir, "originalFASTQ")):
+            os.mkdir(os.path.join(outputDir, "originalFASTQ"))
+        newName = os.path.join(outputDir, "originalFASTQ", bname)
         os.symlink(fname, newName)
     stripRights(outputDir)
     touchDone(outputDir)
@@ -360,21 +442,63 @@ def DNA(config, group, project, organism, libraryType, tuples):
     project = BRB.misc.pacifier(project)
     org_name, org_label, org_yaml = organism
     outputDir = createPath(config, group, project, org_label, libraryType, tuples)
-    log.debug('Running snakePipes in output dir ' + outputDir )
+    log.debug("Running snakePipes in output dir " + outputDir)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
     log.debug(os.listdir(outputDir))
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    if libraryType == 'CUTandTag-seq' or libraryType == 'CUTandRUN-seq':
-        CMD = [CMD, 'DNAmapping', '--DAG', '--trim', '--dedup', '--mapq', '3', '--cutntag', '-i', outputDir, '-o', outputDir, org_yaml]
-    elif libraryType == 'ATAC-Seq':
-        CMD = [CMD, 'DNAmapping', '--DAG', '--trim', r"--trimmerOptions '-a nexteraF=CTGTCTCTTATA -A nexteraR=CTGTCTCTTATA'", '--dedup', '--mapq 2', '-i', outputDir, '-o', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    if libraryType == "CUTandTag-seq" or libraryType == "CUTandRUN-seq":
+        CMD = [
+            CMD,
+            "DNAmapping",
+            "--DAG",
+            "--trim",
+            "--dedup",
+            "--mapq",
+            "3",
+            "--cutntag",
+            "-i",
+            outputDir,
+            "-o",
+            outputDir,
+            org_yaml,
+        ]
+    elif libraryType == "ATAC-Seq":
+        CMD = [
+            CMD,
+            "DNAmapping",
+            "--DAG",
+            "--trim",
+            r"--trimmerOptions '-a nexteraF=CTGTCTCTTATA -A nexteraR=CTGTCTCTTATA'",
+            "--dedup",
+            "--mapq 2",
+            "-i",
+            outputDir,
+            "-o",
+            outputDir,
+            org_yaml,
+        ]
     else:
-        CMD = [CMD, 'DNAmapping', '--DAG', '--trim', '--dedup', '--mapq', '3', '-i', outputDir, '-o', outputDir, org_yaml]
+        CMD = [
+            CMD,
+            "DNAmapping",
+            "--DAG",
+            "--trim",
+            "--dedup",
+            "--mapq",
+            "3",
+            "-i",
+            outputDir,
+            "-o",
+            outputDir,
+            org_yaml,
+        ]
     log.info(f"DNA wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
@@ -399,11 +523,13 @@ def WGBS(config, group, project, organism, libraryType, tuples):
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'WGBS', '--DAG', '--trim', '-i', outputDir, '-o', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [CMD, "WGBS", "--DAG", "--trim", "-i", outputDir, "-o", outputDir, org_yaml]
     log.info(f"WGBS wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
@@ -426,17 +552,21 @@ def ATAC(config, group, project, organism, libraryType, tuples):
         return outputDir, 0, False
 
     if not os.path.exists(os.path.join(outputDir, "DNA.done")):
-        outputDir, rv, sambaret  = DNA(config, group, project, organism, libraryType, tuples)
+        outputDir, rv, sambaret = DNA(
+            config, group, project, organism, libraryType, tuples
+        )
         if rv != 0:
             return outputDir, rv, sambaret
 
         removeDone(outputDir)
         touchDone(outputDir, "DNA.done")
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'ATACseq', '--DAG', '-d', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [CMD, "ATACseq", "--DAG", "-d", outputDir, org_yaml]
     log.info(f"ATAC wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     tidyUpABit(outputDir)
@@ -461,34 +591,55 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
         return outputDir, 0, True
 
     accepted_names = [
-        'Chromium_NextGEM_SingleCell3Prime_GeneExpression_v3.1_DualIndex',
-        'Chromium_GEM-X_SingleCell_3primeRNA-seq_v4'
+        "Chromium_NextGEM_SingleCell3Prime_GeneExpression_v3.1_DualIndex",
+        "Chromium_GEM-X_SingleCell_3primeRNA-seq_v4",
     ]
 
-
     if tuples[0][2] in accepted_names:
-        if 'GRCh38' in org_yaml:
-            org_yaml = 'GRCh38'
+        if "GRCh38" in org_yaml:
+            org_yaml = "GRCh38"
         PE = linkFiles(config, group, project, outputDir, tuples)
-        snakeMakePath= "{}/bin".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-        CMD = [config.get('10x', 'RNA'), outputDir, outputDir, org_yaml, " --snakemakePath ", snakeMakePath]
+        snakeMakePath = "{}/bin".format(
+            os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+        )
+        CMD = [
+            config.get("10x", "RNA"),
+            outputDir,
+            outputDir,
+            org_yaml,
+            " --snakemakePath ",
+            snakeMakePath,
+        ]
         log.info(f"scRNA wf CMD: {' '.join(CMD)}")
         try:
-            subprocess.check_call(' '.join(CMD), shell=True)
+            subprocess.check_call(" ".join(CMD), shell=True)
         except:
             return outputDir, 1, False
         removeLinkFiles(outputDir)
         tidyUpABit(outputDir)
         stripRights(outputDir)
-        copyCellRanger(config,outputDir)
+        copyCellRanger(config, outputDir)
         sambaUpdate = True
     elif tuples[0][2] == "Cel-Seq 2 for single cell RNA-Seq":
         PE = linkFiles(config, group, project, outputDir, tuples)
-        CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-        CMD = [CMD, 'scRNAseq', '--DAG', '--myKit CellSeq384','--skipVelocyto' , '-i', outputDir, '-o', outputDir, org_yaml]
+        CMD = "PATH={}/bin:$PATH".format(
+            os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+        )
+        CMD = [
+            CMD,
+            "scRNAseq",
+            "--DAG",
+            "--myKit CellSeq384",
+            "--skipVelocyto",
+            "-i",
+            outputDir,
+            "-o",
+            outputDir,
+            org_yaml,
+        ]
         log.info(f"scRNA wf CMD: {CMD}")
         try:
-            subprocess.check_call(' '.join(CMD), shell=True)
+            subprocess.check_call(" ".join(CMD), shell=True)
         except:
             return outputDir, 1, False
         removeLinkFiles(outputDir)
@@ -501,7 +652,6 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
 
     touchDone(outputDir)
     return outputDir, 0, sambaUpdate
-
 
 
 def HiC(config, group, project, organism, libraryType, tuples):
@@ -522,11 +672,25 @@ def HiC(config, group, project, organism, libraryType, tuples):
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'HiC', '--DAG', '--noTAD', '--enzyme', 'DpnII', '-i', outputDir, '-o', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [
+        CMD,
+        "HiC",
+        "--DAG",
+        "--noTAD",
+        "--enzyme",
+        "DpnII",
+        "-i",
+        outputDir,
+        "-o",
+        outputDir,
+        org_yaml,
+    ]
     log.info(f"HiC wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
@@ -535,6 +699,7 @@ def HiC(config, group, project, organism, libraryType, tuples):
     stripRights(outputDir)
     touchDone(outputDir)
     return outputDir, 0, False
+
 
 def makePairs(config, group, project, organism, libraryType, tuples):
     """
@@ -546,11 +711,13 @@ def makePairs(config, group, project, organism, libraryType, tuples):
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, False
     PE = linkFiles(config, group, project, outputDir, tuples)
-    CMD = "PATH={}/bin:$PATH".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-    CMD = [CMD, 'makePairs', '--DAG', '-i', outputDir, '-o', outputDir, org_yaml]
+    CMD = "PATH={}/bin:$PATH".format(
+        os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+    )
+    CMD = [CMD, "makePairs", "--DAG", "-i", outputDir, "-o", outputDir, org_yaml]
     log.info(f"makePairs wf CMD: {CMD}")
     try:
-        subprocess.check_call(' '.join(CMD), shell=True)
+        subprocess.check_call(" ".join(CMD), shell=True)
     except:
         return outputDir, 1, False
     removeLinkFiles(outputDir)
@@ -564,32 +731,36 @@ def scATAC(config, group, project, organism, libraryType, tuples):
     """
     scATAC 10x
     """
-    
+
     project = BRB.misc.pacifier(project)
     org_name, org_label, org_yaml = organism
     outputDir = createPath(config, group, project, org_label, libraryType, tuples)
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
         return outputDir, 0, True
-    runID = config.get('Options', 'runID').split("_lanes")[0]
+    runID = config.get("Options", "runID").split("_lanes")[0]
     if (
         tuples[0][2] == "scATAC-Seq 10xGenomics"
         or tuples[0][2] == "Next GEM Single Cell ATAC"
         or tuples[0][2] == "Chromium Next GEM Single Cell ATAC v2"
     ):
         # PE = linkFiles(config, group, project, outputDir, tuples)
-        samples = ' '.join(i[1] for i in tuples)
-        inDir = "{}/{}/{}/{}/Project_{}".format(config.get('Paths', 'groupData'),
-                                               BRB.misc.pacifier(group),
-                                               BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-                                               config.get('Options', 'runID'),
-                                               BRB.misc.pacifier(project))
+        samples = " ".join(i[1] for i in tuples)
+        inDir = "{}/{}/{}/{}/Project_{}".format(
+            config.get("Paths", "groupData"),
+            BRB.misc.pacifier(group),
+            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+            config.get("Options", "runID"),
+            BRB.misc.pacifier(project),
+        )
 
-        snakeMakePath= "{}/bin".format(os.path.join(config.get('Options', 'snakemakeWorkflowBaseDir')))
-        CMD = config.get('10x', 'ATAC')+" -i "+inDir
-        CMD += " -o "+outputDir
-        CMD += " "+org_yaml
-        CMD += " --projectID "+project+" --samples "+ samples
-        CMD += " --snakemakePath "+snakeMakePath
+        snakeMakePath = "{}/bin".format(
+            os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
+        )
+        CMD = config.get("10x", "ATAC") + " -i " + inDir
+        CMD += " -o " + outputDir
+        CMD += " " + org_yaml
+        CMD += " --projectID " + project + " --samples " + samples
+        CMD += " --snakemakePath " + snakeMakePath
 
         log.info(f"scATAC wf CMD: {CMD}")
         try:
@@ -597,14 +768,14 @@ def scATAC(config, group, project, organism, libraryType, tuples):
         except:
             return outputDir, 1, False
         # removeLinkFiles(outputDir)
-        copyCellRanger(config,outputDir)
+        copyCellRanger(config, outputDir)
         stripRights(outputDir)
         tidyUpABit(outputDir)
     else:
         log.info(f"Unsupported protocol: {tuples[0][2]}, just passing the data")
         touchDone(outputDir)
         return outputDir, 0, False
-    
+
     touchDone(outputDir)
     return outputDir, 0, True
 
@@ -628,17 +799,20 @@ def GetResults(config, project, libraries):
         group = project.split("_")[-1].split("-")[0].lower()
         group = BRB.misc.pacifier(group)
         dataPath = Path(
-            config.get('Paths', 'groupData'),
+            config.get("Paths", "groupData"),
             group,
-            BRB.misc.getLatestSeqdir(config.get('Paths','groupData'), group),
-            config.get('Options', 'runID'),
-            'Project_' + BRB.misc.pacifier(project)
+            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+            config.get("Options", "runID"),
+            "Project_" + BRB.misc.pacifier(project),
         )
         log.info(f"Processing {dataPath}")
     except:
         ignore = True
-    validLibraryTypes = {v: i for i, v in enumerate(config.get('Options', 'validLibraryTypes').split(','))}
-    pipelines = config.get('Options', 'pipelines').split(',')
+    validLibraryTypes = {
+        v: i
+        for i, v in enumerate(config.get("Options", "validLibraryTypes").split(","))
+    }
+    pipelines = config.get("Options", "pipelines").split(",")
     # split by analysis type and species, since we can only process some types of this
     analysisTypes = dict()
     skipList = []
@@ -653,8 +827,16 @@ def GetResults(config, project, libraries):
         else:
             log.info(f"Not a ValidLibraryType for sample {library} = {libraryType}")
         if not (org_label or org_yaml):
-            log.info(f"Species label or YAML was not set for {org_name} (check Parkour DB.)")
-        if libraryType in validLibraryTypes and (org_label or org_yaml) and (ignore==False or libraryType in config.get('external','LibraryTypes')):
+            log.info(
+                f"Species label or YAML was not set for {org_name} (check Parkour DB.)"
+            )
+        if (
+            libraryType in validLibraryTypes
+            and (org_label or org_yaml)
+            and (
+                ignore == False or libraryType in config.get("external", "LibraryTypes")
+            )
+        ):
             if org_label not in org_dict:
                 org_dict[org_label] = organism
             idx = validLibraryTypes[libraryType]
@@ -665,48 +847,90 @@ def GetResults(config, project, libraries):
                 analysisTypes[pipeline][org_label] = dict()
             if libraryType not in analysisTypes[pipeline][org_label]:
                 analysisTypes[pipeline][org_label][libraryType] = list()
-            analysisTypes[pipeline][org_label][libraryType].append([library, sampleName, libraryProtocol, ignore])
+            analysisTypes[pipeline][org_label][libraryType].append(
+                [library, sampleName, libraryProtocol, ignore]
+            )
             log.debug(f"Considering analysis types: {analysisTypes}")
         else:
             if ignore == False:
-               skipList.append([library, sampleName, libraryType])
+                skipList.append([library, sampleName, libraryType])
             else:
-               external_skipList.append([library, sampleName, libraryType])
+                external_skipList.append([library, sampleName, libraryType])
     msg = []
     if len(skipList):
         for i in skipList:
-            log.info(f"Skipping sample {i[0]}/{i[0]} ({org_name} - project {BRB.misc.pacifier(project)}).\n")
-        msg = msg + [BRB.ET.telegraphHome(config, group, BRB.misc.pacifier(project), skipList, org_name)]
+            log.info(
+                f"Skipping sample {i[0]}/{i[0]} ({org_name} - project {BRB.misc.pacifier(project)}).\n"
+            )
+        msg = msg + [
+            BRB.ET.telegraphHome(
+                config, group, BRB.misc.pacifier(project), skipList, org_name
+            )
+        ]
     log.debug(config)
     for pipeline, v in analysisTypes.items():
-        log.debug('Running pipeline ' + pipeline)
+        log.debug("Running pipeline " + pipeline)
         for org_label, v2 in v.items():
-            log.debug('Running organism label ' + org_label)
+            log.debug("Running organism label " + org_label)
             organism = org_dict[org_label]
             org_name, org_label, org_yaml = organism
             log.debug(organism)
             for libraryType, tuples in v2.items():
-                log.debug('Running libraryType ' + libraryType)
+                log.debug("Running libraryType " + libraryType)
                 log.debug(tuples)
                 reruncount = 0
                 # RELACS needs the unpacified project name to copy the original sample sheet to the dest dir
                 # hence the pacifier is applied on the project in each pipeline separately
-                
-                outputDir, rv, sambaUpdate = globals()[pipeline](config, group, project, organism, libraryType, tuples)
+
+                outputDir, rv, sambaUpdate = globals()[pipeline](
+                    config, group, project, organism, libraryType, tuples
+                )
                 if reruncount == 0 and rv != 0:
                     # Allow for one re-run
                     reruncount += 1
-                    outputDir, rv, sambaUpdate = globals()[pipeline](config, group, project, organism, libraryType, tuples)
+                    outputDir, rv, sambaUpdate = globals()[pipeline](
+                        config, group, project, organism, libraryType, tuples
+                    )
                 if rv == 0:
-                    log.debug('BRB run for {} {} {} {} complete.'.format(pipeline,org_label,libraryType,tuples))
-                    msg = msg + [BRB.ET.phoneHome(config, outputDir, pipeline, tuples, org_name, project, libraryType) + [sambaUpdate, reruncount]]
-                    log.info(f"Processed project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {org_name}. Rerun = {reruncount}")
+                    log.debug(
+                        "BRB run for {} {} {} {} complete.".format(
+                            pipeline, org_label, libraryType, tuples
+                        )
+                    )
+                    msg = msg + [
+                        BRB.ET.phoneHome(
+                            config,
+                            outputDir,
+                            pipeline,
+                            tuples,
+                            org_name,
+                            project,
+                            libraryType,
+                        )
+                        + [sambaUpdate, reruncount]
+                    ]
+                    log.info(
+                        f"Processed project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {org_name}. Rerun = {reruncount}"
+                    )
                 else:
-                    msg = msg + [[project, org_name, libraryType, pipeline, 'FAILED', 'not updated', sambaUpdate, reruncount]]
-                    log.warning(f"FAILED project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {org_name}. Rerun = {reruncount}")
+                    msg = msg + [
+                        [
+                            project,
+                            org_name,
+                            libraryType,
+                            pipeline,
+                            "FAILED",
+                            "not updated",
+                            sambaUpdate,
+                            reruncount,
+                        ]
+                    ]
+                    log.warning(
+                        f"FAILED project {BRB.misc.pacifier(project)} with the {pipeline} pipeline. {libraryType}, {org_name}. Rerun = {reruncount}"
+                    )
     # In case there is an external_skipList, there shouldn't be a skipList !
     if external_skipList:
         assert not skipList
-        libTypes = ','.join(set([i[2] for i in external_skipList]))
+        libTypes = ",".join(set([i[2] for i in external_skipList]))
         msg = msg + [[project, org_name, libTypes, None, None, None, False, None]]
     return msg

--- a/BRB/demultiplex_relacs.py
+++ b/BRB/demultiplex_relacs.py
@@ -10,12 +10,34 @@ import numpy as np
 import BRB.editdistance as ed
 from rich import print
 
+
 def parseArgs(args=None):
-    parser = argparse.ArgumentParser(description="Process RELACS reads by moving a barcode into the header and writing output to per-barcode files.")
-    parser.add_argument('-p', '--numThreads', help='Number of threads to use. Note that there will only ever be a single thread used per illumina sample, so there is no reason so specify more threads than samples. Note also that the effective number of threads used will always be higher than this, since compression/decompression for each file occurs in a separate thread.', type=int, default=1)
-    parser.add_argument('-b', '--buffer', help='Number of bases of "buffer" to ignore after the barcode. (default: 1)', type=int, default=1)
-    parser.add_argument('--umiLength', type=int, default=0, help="If present, the number of bases to be used as the UMI. These proceed the cell barcode.")
-    parser.add_argument('sampleTable', help="""A tab-separated table with three columns: Illumina sample	barcode	sample_name
+    parser = argparse.ArgumentParser(
+        description="Process RELACS reads by moving a barcode into the header and writing output to per-barcode files."
+    )
+    parser.add_argument(
+        "-p",
+        "--numThreads",
+        help="Number of threads to use. Note that there will only ever be a single thread used per illumina sample, so there is no reason so specify more threads than samples. Note also that the effective number of threads used will always be higher than this, since compression/decompression for each file occurs in a separate thread.",
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "-b",
+        "--buffer",
+        help='Number of bases of "buffer" to ignore after the barcode. (default: 1)',
+        type=int,
+        default=1,
+    )
+    parser.add_argument(
+        "--umiLength",
+        type=int,
+        default=0,
+        help="If present, the number of bases to be used as the UMI. These proceed the cell barcode.",
+    )
+    parser.add_argument(
+        "sampleTable",
+        help="""A tab-separated table with three columns: Illumina sample	barcode	sample_name
 
 An example is:
 
@@ -28,15 +50,21 @@ The "Illumina sample" column corresponds to a directory with fastq files, as pro
 Any observed barcode that does not match a barcode listed in the file (with a possible mismatch of 1) will be written to the sample specified by 'default'. Note that all barcodes must be of the same length.
 
 This script must be run in directory containing subdirectories each having fastq files. This is the default structure output by bcl2fastq2 and our internal demultiplexing pipeline.
-""")
-    parser.add_argument('output', metavar='output_basename', help="Base output directory, which must exist. As an example, if a given PE read has the barcode ACTACT, then it will be written to /output_basename/Sample_Lib_C838_11/Sample_R1.fastq.gz and /output_basename/Sample_Lib_C838_11/Sample_R2.fastq.gz")
-    parser.add_argument('--version', action='version', version="%(prog)s 1.0")
+""",
+    )
+    parser.add_argument(
+        "output",
+        metavar="output_basename",
+        help="Base output directory, which must exist. As an example, if a given PE read has the barcode ACTACT, then it will be written to /output_basename/Sample_Lib_C838_11/Sample_R1.fastq.gz and /output_basename/Sample_Lib_C838_11/Sample_R2.fastq.gz",
+    )
+    parser.add_argument("--version", action="version", version="%(prog)s 1.0")
     args = parser.parse_args(args)
 
     if args.sampleTable is None or args.output is None:
         parser.print_help()
 
     return args
+
 
 def checkDuplicatedLabels(data):
     """
@@ -45,7 +73,7 @@ def checkDuplicatedLabels(data):
     """
     num_bar = 0
     labels = set()
-    
+
     for sample in data:
         num_bar += len(data[sample])
         for barcode in data[sample]:
@@ -77,14 +105,14 @@ def readSampleTable(sampleTable):
             elif len(elem) == 4:
                 sample, bc_pos, barcode, label = elem
             # sanitize label
-            label = label.replace(' ', '_')
+            label = label.replace(" ", "_")
             if sample not in d:
                 d[sample] = dict()
             d[sample][barcode] = [label, bc_pos]
-            
-            if barcode != 'default' and len(barcode) > bcLen:
+
+            if barcode != "default" and len(barcode) > bcLen:
                 bcLen = len(barcode)
-    
+
     if len(d) < 1 or bcLen == 0:
         print(f"Samplesheet is empty: {sampleTable}, aborting")
         sys.exit(1)
@@ -100,8 +128,10 @@ def matchSample(sequence, sequence2, oDict, bcLen, umiLength):
 
     Returns a tuple of the list of file pointers and True/False (whether the "default" output is being used)
     """
-    bc = sequence[umiLength:bcLen + umiLength]
-    bc2 = sequence2[umiLength:bcLen + umiLength] if sequence2 else None  # For whatever reason, padding isn't used
+    bc = sequence[umiLength : bcLen + umiLength]
+    bc2 = (
+        sequence2[umiLength : bcLen + umiLength] if sequence2 else None
+    )  # For whatever reason, padding isn't used
     if bc in oDict:
         if bc2 and ed.eval(bc, bc2) < 2:
             return (bc, True)
@@ -129,11 +159,11 @@ def writeRead(lineList, of, bc, bcLen, args, doTrim=True):
     if doTrim:
         UMI = ""
         if args.umiLength > 0:
-            UMI = lineList[1][:args.umiLength]
+            UMI = lineList[1][: args.umiLength]
 
         # Trim off the barcode
-        lineList[1] = lineList[1][bcLen + args.buffer + args.umiLength:]
-        lineList[3] = lineList[3][bcLen + args.buffer + args.umiLength:]
+        lineList[1] = lineList[1][bcLen + args.buffer + args.umiLength :]
+        lineList[3] = lineList[3][bcLen + args.buffer + args.umiLength :]
 
         # Fix the read name
         rname = rname.split()
@@ -143,8 +173,8 @@ def writeRead(lineList, of, bc, bcLen, args, doTrim=True):
             rname[0] = "{}_{}".format(rname[0], bc)
         rname = " ".join(rname)
 
-    if rname[-1] != '\n':
-        rname += '\n'
+    if rname[-1] != "\n":
+        rname += "\n"
 
     of.write(rname.encode())
     of.write(lineList[1].encode())
@@ -161,13 +191,13 @@ def writeRead2(lineList, of, bcLen, args, doTrim=True):
     rname[1] = "2{}".format(rname[1][1:])
     rname = " ".join(rname)
 
-    if rname[-1] != '\n':
-        rname += '\n'
+    if rname[-1] != "\n":
+        rname += "\n"
 
     if doTrim:
         # trim off the barcode
-        lineList[1] = lineList[1][bcLen + args.buffer + args.umiLength:]
-        lineList[3] = lineList[3][bcLen + args.buffer + args.umiLength:]
+        lineList[1] = lineList[1][bcLen + args.buffer + args.umiLength :]
+        lineList[3] = lineList[3][bcLen + args.buffer + args.umiLength :]
 
     of.write(rname.encode())
     of.write(lineList[1].encode())
@@ -176,21 +206,20 @@ def writeRead2(lineList, of, bcLen, args, doTrim=True):
 
 
 def writePaired(read1, read2, of, bc, bcLen, args, doTrim=True):
-    """
-    """
+    """ """
     rname = read1[0]
     if doTrim:
         UMI = ""
         if args.umiLength > 0:
-            UMI = read1[1][:args.umiLength]
-            UMI += read2[1][:args.umiLength]
+            UMI = read1[1][: args.umiLength]
+            UMI += read2[1][: args.umiLength]
 
         # Trim off the barcode
-        read1[1] = read1[1][bcLen + args.buffer + args.umiLength:]
-        read1[3] = read1[3][bcLen + args.buffer + args.umiLength:]
+        read1[1] = read1[1][bcLen + args.buffer + args.umiLength :]
+        read1[3] = read1[3][bcLen + args.buffer + args.umiLength :]
 
-        read2[1] = read2[1][bcLen + args.buffer + args.umiLength:]
-        read2[3] = read2[3][bcLen + args.buffer + args.umiLength:]
+        read2[1] = read2[1][bcLen + args.buffer + args.umiLength :]
+        read2[3] = read2[3][bcLen + args.buffer + args.umiLength :]
 
         # Fix the read name
         rname = rname.split()
@@ -200,9 +229,9 @@ def writePaired(read1, read2, of, bc, bcLen, args, doTrim=True):
             rname[0] = "{}_{}".format(rname[0], bc)
         rname = " ".join(rname)
 
-    if rname[-1] != '\n':
-        rname += '\n'
-    
+    if rname[-1] != "\n":
+        rname += "\n"
+
     of[0].write(rname.encode())
     of[0].write(read1[1].encode())
     of[0].write(read1[2].encode())
@@ -212,13 +241,23 @@ def writePaired(read1, read2, of, bc, bcLen, args, doTrim=True):
     of[1].write(read2[1].encode())
     of[1].write(read2[2].encode())
     of[1].write(read2[3].encode())
-    
+
     return bc
 
 
 def processPaired(args, sDict, bcLen, read1, read2, bc_dict, ori_rDict):
-    f1_ = subprocess.Popen("gunzip -c {}".format(read1), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    f2_ = subprocess.Popen("gunzip -c {}".format(read2), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    f1_ = subprocess.Popen(
+        "gunzip -c {}".format(read1),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    f2_ = subprocess.Popen(
+        "gunzip -c {}".format(read2),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     f1 = f1_.stdout
     f2 = f2_.stdout
     false_bc = 0
@@ -233,22 +272,35 @@ def processPaired(args, sDict, bcLen, read1, read2, bc_dict, ori_rDict):
         line2_4 = f2.readline().decode("ascii")
         (bc, isDefault) = matchSample(line1_2, line2_2, sDict, bcLen, args.umiLength)
 
-        relacs_bc = writePaired([line1_1, line1_2, line1_3, line1_4], [line1_2,line2_2, line2_3, line2_4], sDict[bc], bc, bcLen, args, isDefault)
+        relacs_bc = writePaired(
+            [line1_1, line1_2, line1_3, line1_4],
+            [line1_2, line2_2, line2_3, line2_4],
+            sDict[bc],
+            bc,
+            bcLen,
+            args,
+            isDefault,
+        )
 
         if isDefault is True:
-           if relacs_bc not in bc_dict.keys():
-              bc_dict[bc] = 1
-           else:
-              bc_dict[bc] += 1
-        else: 
-              false_bc += 1
+            if relacs_bc not in bc_dict.keys():
+                bc_dict[bc] = 1
+            else:
+                bc_dict[bc] += 1
+        else:
+            false_bc += 1
     plot_bc_occurance(read1, bc_dict, false_bc, args.output, ori_rDict)
     f1.close()
     f2.close()
 
 
 def processSingle(args, sDict, bcLen, read1):
-    f1_ = subprocess.Popen("gunzip -c {}".format(read1), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    f1_ = subprocess.Popen(
+        "gunzip -c {}".format(read1),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     f1 = f1_.stdout
 
     for line1_1 in f1:
@@ -257,7 +309,9 @@ def processSingle(args, sDict, bcLen, read1):
         line1_3 = f1.readline().decode("ascii")
         line1_4 = f1.readline().decode("ascii")
         (bc, isDefault) = matchSample(line1_2, None, sDict, bcLen, args.umiLength)
-        writeRead([line1_1, line1_2, line1_3, line1_4], sDict[bc], bc, bcLen, args, isDefault)
+        writeRead(
+            [line1_1, line1_2, line1_3, line1_4], sDict[bc], bc, bcLen, args, isDefault
+        )
 
     f1.close()
 
@@ -276,7 +330,11 @@ def wrapper(foo):
     R1 = glob.glob("{}/*_R1.fastq.gz".format(d))
     R2 = None
     if len(R1) > 1:
-        print("Warning, there was more than 1 sample found in {}, only {} will be used".format(d, R1[0]))
+        print(
+            "Warning, there was more than 1 sample found in {}, only {} will be used".format(
+                d, R1[0]
+            )
+        )
     R1 = R1[0]
     if os.path.exists("{}_R2.fastq.gz".format(R1[:-12])):
         R2 = "{}_R2.fastq.gz".format(R1[:-12])
@@ -285,79 +343,189 @@ def wrapper(foo):
     oDict = dict()
     if R2 is not None:
         for k, v in sDict.items():
-            oDict[k] = [subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R1.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin,
-                        subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R2.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin]
-        if 'default' not in oDict:
-            k = 'default'
-            v = ['unknown', '']
-            oDict[k] = [subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R1.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin,
-                        subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R2.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin]
+            oDict[k] = [
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R1.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin,
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R2.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin,
+            ]
+        if "default" not in oDict:
+            k = "default"
+            v = ["unknown", ""]
+            oDict[k] = [
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R1.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin,
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R2.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin,
+            ]
         processPaired(args, oDict, bcLen, R1, R2, bc_dict, sDict)
     else:
         for k, v in sDict.items():
-            oDict[k] = [subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R1.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin]
-        if 'default' not in oDict:
-            k = 'default'
-            v = 'unknown'
-            oDict[k] = [subprocess.Popen(['gzip', '-c'], stdout=open('{}/{}/{}_R1.fastq.gz'.format(args.output, d, v[0]), "wb"), stdin=subprocess.PIPE, bufsize=0).stdin]
+            oDict[k] = [
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R1.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin
+            ]
+        if "default" not in oDict:
+            k = "default"
+            v = "unknown"
+            oDict[k] = [
+                subprocess.Popen(
+                    ["gzip", "-c"],
+                    stdout=open(
+                        "{}/{}/{}_R1.fastq.gz".format(args.output, d, v[0]), "wb"
+                    ),
+                    stdin=subprocess.PIPE,
+                    bufsize=0,
+                ).stdin
+            ]
         processSingle(args, oDict, bcLen, R1)
     return bc_dict
+
 
 def plot_bc_occurance(R1, bc_dict, false_bc, output_path, sDict):
     # Deepseq likes to have the BC coordinates in a specific order
     BC_ORDER = [
-        "A1-21","B1-22","C1-23","D1-24","E1-25","F1-26","G1-27",
-        "H1-28","A2-29","B2-30","C2-31","D2-32","E2-33","F2-34",
-        "G2-35","H2-36","A3-37","B3-38","C3-39","D3-40","E3-41",
-        "F3-42","G3-43","H3-44","A4-45","B4-46","C4-47","D4-48",
-        "E4-49","F4-50","A1-51","B1-52","C1-53","D1-54","E1-55",
-        "F1-56","G1-57","H1-58","A2-59","B2-60","C2-61","D2-62",
-        "E2-63","F2-64","G2-65","H2-66","A3-67","B3-68","C3-69",
-        "D3-70","E3-71","F3-72","G3-73","H3-74","A4-75","B4-76",
-        "C4-77","D4-78","E4-79","F4-80"
+        "A1-21",
+        "B1-22",
+        "C1-23",
+        "D1-24",
+        "E1-25",
+        "F1-26",
+        "G1-27",
+        "H1-28",
+        "A2-29",
+        "B2-30",
+        "C2-31",
+        "D2-32",
+        "E2-33",
+        "F2-34",
+        "G2-35",
+        "H2-36",
+        "A3-37",
+        "B3-38",
+        "C3-39",
+        "D3-40",
+        "E3-41",
+        "F3-42",
+        "G3-43",
+        "H3-44",
+        "A4-45",
+        "B4-46",
+        "C4-47",
+        "D4-48",
+        "E4-49",
+        "F4-50",
+        "A1-51",
+        "B1-52",
+        "C1-53",
+        "D1-54",
+        "E1-55",
+        "F1-56",
+        "G1-57",
+        "H1-58",
+        "A2-59",
+        "B2-60",
+        "C2-61",
+        "D2-62",
+        "E2-63",
+        "F2-64",
+        "G2-65",
+        "H2-66",
+        "A3-67",
+        "B3-68",
+        "C3-69",
+        "D3-70",
+        "E3-71",
+        "F3-72",
+        "G3-73",
+        "H3-74",
+        "A4-75",
+        "B4-76",
+        "C4-77",
+        "D4-78",
+        "E4-79",
+        "F4-80",
     ]
     _k_order = []
     for _bc in BC_ORDER:
         for k, v in sorted(bc_dict.items()):
-            if sDict[str(k)][1] == '' and k not in _k_order:
+            if sDict[str(k)][1] == "" and k not in _k_order:
                 _k_order.append(k)
             elif sDict[str(k)][1] == _bc:
                 _k_order.append(k)
     assert len(_k_order) == len(bc_dict.keys())
 
     total_sum = false_bc
-    for k,v in bc_dict.items():
+    for k, v in bc_dict.items():
         total_sum += v
 
-    percentages = [float(false_bc/total_sum)*100]
+    percentages = [float(false_bc / total_sum) * 100]
     x_ticks = ["false_bc"]
 
     for k in _k_order:
         v = bc_dict[k]
-        percentages.append(float(v/total_sum)*100)
-        if sDict[str(k)][1] == '':
-            x_ticks.append(str(k) + ' ' + sDict[str(k)][0])
+        percentages.append(float(v / total_sum) * 100)
+        if sDict[str(k)][1] == "":
+            x_ticks.append(str(k) + " " + sDict[str(k)][0])
         else:
-            x_ticks.append(sDict[str(k)][1] + ' ' + sDict[str(k)][0])
-    
+            x_ticks.append(sDict[str(k)][1] + " " + sDict[str(k)][0])
+
     percentages = np.asarray(percentages)
     bc_mean = np.mean(percentages[1:])
-    exp_value = 100/float(len(percentages[1:]))
+    exp_value = 100 / float(len(percentages[1:]))
     bc_std = np.std(percentages[1:] - exp_value)
-    fig,ax = plt.subplots(dpi=300)
+    fig, ax = plt.subplots(dpi=300)
     x = np.arange(len(percentages))
     ax.bar(x, percentages)
     ax.set_xticks(x)
-    ax.set_xticklabels(x_ticks, rotation='vertical', fontsize = 6)
-    exp_value = 100/(len(x)-1)
-    ax.axhline(y=exp_value, linestyle="--", linewidth=0.5, color='k')
-    xx = [-1]+list(range(len(x)))+[len(x)+1]
-    ax.fill_between(xx, [bc_mean + bc_std]*len(xx), [bc_mean - bc_std]*len(xx), color='dimgrey', alpha=0.2, zorder=3)
+    ax.set_xticklabels(x_ticks, rotation="vertical", fontsize=6)
+    exp_value = 100 / (len(x) - 1)
+    ax.axhline(y=exp_value, linestyle="--", linewidth=0.5, color="k")
+    xx = [-1] + list(range(len(x))) + [len(x) + 1]
+    ax.fill_between(
+        xx,
+        [bc_mean + bc_std] * len(xx),
+        [bc_mean - bc_std] * len(xx),
+        color="dimgrey",
+        alpha=0.2,
+        zorder=3,
+    )
     plt.ylabel("% of total reads")
     sample_name = R1.split("_R1")[0]
-    fig_path_name = os.path.join(output_path,sample_name+"_fig.png")
+    fig_path_name = os.path.join(output_path, sample_name + "_fig.png")
     plt.tight_layout()
-    plt.savefig(fig_path_name, pad_inches=0.6, bbox_inches='tight')
+    plt.savefig(fig_path_name, pad_inches=0.6, bbox_inches="tight")
+
 
 def main(args=None):
     args = parseArgs(args)

--- a/BRB/email.py
+++ b/BRB/email.py
@@ -6,52 +6,70 @@ from dominate.tags import html, div, br
 from tabulate import tabulate
 from BRB.logger import log
 
-def errorEmail(config, errTuple, msg) :
-    msg = MIMEText(msg + "\nError type: %s\nError value: %s\n%s\n" % (errTuple[0], errTuple[1], errTuple[2]))
-    msg['Subject'] = f'[BigRedButton {version("BRB")}] Error'
-    msg['From'] = config.get("Email","fromAddress")
-    msg['To'] = config.get("Email","errorTo")
 
-    s = smtplib.SMTP(config.get("Email","host"))
+def errorEmail(config, errTuple, msg):
+    msg = MIMEText(
+        msg
+        + "\nError type: %s\nError value: %s\n%s\n"
+        % (errTuple[0], errTuple[1], errTuple[2])
+    )
+    msg["Subject"] = f"[BigRedButton {version('BRB')}] Error"
+    msg["From"] = config.get("Email", "fromAddress")
+    msg["To"] = config.get("Email", "errorTo")
+
+    s = smtplib.SMTP(config.get("Email", "host"))
     s.send_message(msg)
     s.quit()
 
 
 def finishedEmail(config, msg):
-    mailer = MIMEMultipart('alternative')
-    mailer['Subject'] = f'[BigRedButton {version("BRB")}] {config.get("Options","runID")} processed'
-    mailer['From'] = config.get("Email","fromAddress")
-    
+    mailer = MIMEMultipart("alternative")
+    mailer["Subject"] = (
+        f"[BigRedButton {version('BRB')}] {config.get('Options', 'runID')} processed"
+    )
+    mailer["From"] = config.get("Email", "fromAddress")
+
     # Create the table head
     _html = html()
     # Default recipient is finishedTo (bioinfocore)
-    recipient = config.get("Email","finishedTo")
+    recipient = config.get("Email", "finishedTo")
     # Inform deepseq too if we have a sambaUpdate:
     if any([i[6] for i in msg]):
         log.info("At least one sambaUpdate true in msg")
         # Only inform deepseq if no workflow failed
-        if [i[4] for i in msg].count('FAILED') == 0:
-            recipient = config.get("Email","deepSeq")
-            _html.add(div(
-                f'Post-processing is ready, Samba drive is updated for {[i[6] for i in msg].count(True)} project(s).',
-                br()
-            ))
+        if [i[4] for i in msg].count("FAILED") == 0:
+            recipient = config.get("Email", "deepSeq")
+            _html.add(
+                div(
+                    f"Post-processing is ready, Samba drive is updated for {[i[6] for i in msg].count(True)} project(s).",
+                    br(),
+                )
+            )
 
-    mailer['To'] = recipient
+    mailer["To"] = recipient
     # Table
-    tabHead = ['Project', 'organism', 'libraryType', 'workflow', 'workflow_status', 'parkour_status', 'sambaUpdate', 'reruns']
-    message =  _html.render() + '\n\n' + tabulate(
-        msg, tabHead, tablefmt="html", disable_numparse=True
+    tabHead = [
+        "Project",
+        "organism",
+        "libraryType",
+        "workflow",
+        "workflow_status",
+        "parkour_status",
+        "sambaUpdate",
+        "reruns",
+    ]
+    message = (
+        _html.render()
+        + "\n\n"
+        + tabulate(msg, tabHead, tablefmt="html", disable_numparse=True)
     )
 
-    email = MIMEText(message, 'html')
+    email = MIMEText(message, "html")
     mailer.attach(email)
-    
+
     s = smtplib.SMTP(config.get("Email", "host"))
-    
+
     s.sendmail(
-        config.get("Email","fromAddress"),
-        recipient.split(','),
-        mailer.as_string()
+        config.get("Email", "fromAddress"), recipient.split(","), mailer.as_string()
     )
     s.quit()

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -7,37 +7,38 @@ from BRB.logger import log
 
 def flowCellProcessed(config):
     return Path(
-        config.get("Paths","baseData"),
-        config.get("Options","runID"),
-        'analysis.done'
+        config.get("Paths", "baseData"), config.get("Options", "runID"), "analysis.done"
     ).exists()
 
 
 def markFinished(config):
-    _p = Path(
-        config["Paths"]["baseData"],
-        config["Options"]["runID"],
-        'analysis.done'
-    )
+    _p = Path(config["Paths"]["baseData"], config["Options"]["runID"], "analysis.done")
     _p.touch()
     log.info(f"{_p} created, flow cell processed.")
     print(f"{_p} created, flow cell processed.")
 
 
 def queryParkour(config):
-    basePath= config.get("Paths","baseData")
+    basePath = config.get("Paths", "baseData")
     sequencer_type = config.get("Options", "sequencerType")
     if sequencer_type == "Aviti":
         FCID = config.get("Options", "runID").split("_")[2]
-        if '-' in FCID:
-            FCID = FCID.split('-')[-1]
-        d = {'flowcell_id': FCID}
+        if "-" in FCID:
+            FCID = FCID.split("-")[-1]
+        d = {"flowcell_id": FCID}
     else:
-        FCID = config.get("Options", "runID").split("_")[3][1:]  # C605HACXX from 150416_SN7001180_0196_BC605HACXX
-        if '-' in FCID:
-            FCID = FCID.split('-')[-1]
-        d = {'flowcell_id': FCID}
-    res = requests.get(config.get("Parkour", "QueryURL"), auth=(config.get("Parkour", "user"), config.get("Parkour", "password")), params=d, verify=config.get("Parkour", "cert"))
+        FCID = config.get("Options", "runID").split("_")[3][
+            1:
+        ]  # C605HACXX from 150416_SN7001180_0196_BC605HACXX
+        if "-" in FCID:
+            FCID = FCID.split("-")[-1]
+        d = {"flowcell_id": FCID}
+    res = requests.get(
+        config.get("Parkour", "QueryURL"),
+        auth=(config.get("Parkour", "user"), config.get("Parkour", "password")),
+        params=d,
+        verify=config.get("Parkour", "cert"),
+    )
     if res.status_code == 200:
         return res.json()
     return dict()
@@ -56,13 +57,13 @@ def detect_sequencer_type(base_path: str) -> str:
 
 
 def newFlowCell(config):
-    dirs = glob.glob("{}/*/fastq.made".format(config.get("Paths","baseData")))
-    for d in dirs :
-        #Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)
+    dirs = glob.glob("{}/*/fastq.made".format(config.get("Paths", "baseData")))
+    for d in dirs:
+        # Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)
         run_id = Path(d).parents[0].name
-        config.set('Options','runID',run_id)
-        
-        if config.get("Options","runID")[:4] < "1804":
+        config.set("Options", "runID", run_id)
+
+        if config.get("Options", "runID")[:4] < "1804":
             continue
 
         # Detect sequencer type
@@ -71,12 +72,14 @@ def newFlowCell(config):
         config.set("Options", "sequencerType", seq_type)
 
         if not flowCellProcessed(config):
-            print(f'Found new flow cell: [green]{config.get("Options","runID")}[/green]')
+            print(
+                f"Found new flow cell: [green]{config.get('Options', 'runID')}[/green]"
+            )
             # Query parkour to see if there's anything to be done for this
             ParkourDict = queryParkour(config)
             if len(ParkourDict) == 0:
                 markFinished(config)
-                config.set('Options','runID', '')
+                config.set("Options", "runID", "")
                 ParkourDict = None
                 continue
             return config, ParkourDict

--- a/BRB/getConfig.py
+++ b/BRB/getConfig.py
@@ -2,20 +2,21 @@ import configparser
 import sys
 import os
 
-def getConfig(configFile=None) :
+
+def getConfig(configFile=None):
     if configFile is None:
-        print('Error: configFile is undefined.')
+        print("Error: configFile is undefined.")
         sys.exit(1)
 
     if not os.path.exists(configFile):
-        print('Error: configFile {} does not exists'.format(configFile))
+        print("Error: configFile {} does not exists".format(configFile))
         sys.exit(1)
 
     config = configparser.ConfigParser()
     config.read_file(open(configFile))
 
-    if("Paths" not in config.sections()) :
-        print('Error: No Paths defined in config {}'.format(configFile))
+    if "Paths" not in config.sections():
+        print("Error: No Paths defined in config {}".format(configFile))
         sys.exit(1)
 
     return config

--- a/BRB/logger.py
+++ b/BRB/logger.py
@@ -8,9 +8,9 @@ def setLog(logFile):
         filename=logFile,
         level="DEBUG",
         format="%(levelname)s    %(asctime)s    %(message)s",
-        filemode='a',
-        force=True
+        filemode="a",
+        force=True,
     )
     log = logging.getLogger()
     log.info("Log Initiated.")
-    return(0)
+    return 0

--- a/BRB/misc.py
+++ b/BRB/misc.py
@@ -11,18 +11,20 @@ def loadUserDictionary():
     f.close()
     return d
 
+
 def getLatestSeqdir(groupData, PI):
     seqDirNum = 0
     for dirs in os.listdir(os.path.join(groupData, PI)):
-        if 'sequencing_data' in dirs:
-            seqDirStrip = dirs.replace('sequencing_data','')
-            if seqDirStrip != '':
+        if "sequencing_data" in dirs:
+            seqDirStrip = dirs.replace("sequencing_data", "")
+            if seqDirStrip != "":
                 if int(seqDirStrip) > seqDirNum:
                     seqDirNum = int(seqDirStrip)
     if seqDirNum == 0:
-        return 'sequencing_data'
+        return "sequencing_data"
     else:
-        return 'sequencing_data' + str(seqDirNum)
+        return "sequencing_data" + str(seqDirNum)
+
 
 def pacifier(s):
     """
@@ -31,5 +33,5 @@ def pacifier(s):
     This only works in python 3
     """
     s = s.replace(" ", "")
-    s = s.replace("'","")
-    return str(unicodedata.normalize('NFKD',s).encode('ASCII', 'ignore'), 'utf-8')
+    s = s.replace("'", "")
+    return str(unicodedata.normalize("NFKD", s).encode("ASCII", "ignore"), "utf-8")

--- a/BRB/run.py
+++ b/BRB/run.py
@@ -13,60 +13,76 @@ from time import sleep
 from pathlib import Path
 from rich import print
 
-@click.command(
-    context_settings=dict(
-        help_option_names=["-h", "--help"]
-    )
-)
+
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option(
-   "-c",
-   "--configfile",
-   type=click.Path(exists=True),
-   required=False,
-   default=os.path.expanduser('~/configs/BigRedButton.ini'),
-   help='specify a custom ini file.',
-   show_default=True
+    "-c",
+    "--configfile",
+    type=click.Path(exists=True),
+    required=False,
+    default=os.path.expanduser("~/configs/BigRedButton.ini"),
+    help="specify a custom ini file.",
+    show_default=True,
 )
 def run_brb(configfile):
-
     while True:
-        #Read the config file
+        # Read the config file
         config = BRB.getConfig.getConfig(configfile)
 
-        #Get the next flow cell to process, or sleep
+        # Get the next flow cell to process, or sleep
         config, ParkourDict = BRB.findFinishedFlowCells.newFlowCell(config)
-        if(config.get('Options','runID') == '') or ParkourDict is None:
-            sleep(60*60)
+        if (config.get("Options", "runID") == "") or ParkourDict is None:
+            sleep(60 * 60)
             continue
 
         # Open log file
         logFile = Path(
-            config['Paths']['logPath'],
-            config.get('Options','runID') + '.log'
+            config["Paths"]["logPath"], config.get("Options", "runID") + ".log"
         )
         print(f"Logging into: {logFile}")
         setLog(logFile)
 
-        #Process each group's data, ignore cases where the project isn't in the lanes being processed
-        bdir = "{}/{}".format(config.get('Paths', 'baseData'), config.get('Options', 'runID'))
+        # Process each group's data, ignore cases where the project isn't in the lanes being processed
+        bdir = "{}/{}".format(
+            config.get("Paths", "baseData"), config.get("Options", "runID")
+        )
         msg = []
         for k, v in ParkourDict.items():
             if not os.path.exists("{}/Project_{}".format(bdir, BRB.misc.pacifier(k))):
-                log.info("{}/Project_{} doesn't exist, probably lives on another lane.".format(bdir, BRB.misc.pacifier(k)))
+                log.info(
+                    "{}/Project_{} doesn't exist, probably lives on another lane.".format(
+                        bdir, BRB.misc.pacifier(k)
+                    )
+                )
                 continue
             try:
                 msg = msg + BRB.PushButton.GetResults(config, k, v)
             except Exception as e:
-                BRB.email.errorEmail(config, sys.exc_info(), "Received an error running PushButton.GetResults() with {} and {}".format(k, v))
-                log.critical("Received an error running PushButton.GetResults() with {} and {}".format(k, v))
-                print("Received an error running PushButton.GetResults() with {} and {}".format(k, v), file=sys.stderr)
+                BRB.email.errorEmail(
+                    config,
+                    sys.exc_info(),
+                    "Received an error running PushButton.GetResults() with {} and {}".format(
+                        k, v
+                    ),
+                )
+                log.critical(
+                    "Received an error running PushButton.GetResults() with {} and {}".format(
+                        k, v
+                    )
+                )
+                print(
+                    "Received an error running PushButton.GetResults() with {} and {}".format(
+                        k, v
+                    ),
+                    file=sys.stderr,
+                )
                 raise
 
-        #Email finished message
-        log.info('Create e-mail')
+        # Email finished message
+        log.info("Create e-mail")
         log.info(msg)
         BRB.email.finishedEmail(config, msg)
 
-        #Mark the flow cell as having been processed
+        # Mark the flow cell as having been processed
         BRB.findFinishedFlowCells.markFinished(config)
-        log.info('=== finished flowcell ===')
+        log.info("=== finished flowcell ===")

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -2,74 +2,83 @@ from pathlib import Path
 import pytest
 import configparser
 import urllib3
-from BRB.findFinishedFlowCells import flowCellProcessed, markFinished, queryParkour, detect_sequencer_type
+from BRB.findFinishedFlowCells import (
+    flowCellProcessed,
+    markFinished,
+    queryParkour,
+    detect_sequencer_type,
+)
 from unittest.mock import patch, Mock
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def ifs(tmp_path_factory):
-  fp = tmp_path_factory.mktemp("flowcells")
-  Path(fp,"fc_fin").mkdir()
-  Path(fp, "fc_fin", "analysis.done").touch()
-  Path(fp,"fc_unfin").mkdir()
-  (fp / "aviti_run" / "flowcellXXX" / "RunManifest.csv").parent.mkdir(parents=True, exist_ok=True)
-  (fp / "aviti_run" / "flowcellXXX" / "RunManifest.csv").touch()
+    fp = tmp_path_factory.mktemp("flowcells")
+    Path(fp, "fc_fin").mkdir()
+    Path(fp, "fc_fin", "analysis.done").touch()
+    Path(fp, "fc_unfin").mkdir()
+    (fp / "aviti_run" / "flowcellXXX" / "RunManifest.csv").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (fp / "aviti_run" / "flowcellXXX" / "RunManifest.csv").touch()
 
-  return fp
+    return fp
 
 
-def create_conf(l = []):
-    '''
+def create_conf(l=[]):
+    """
     sets up a config, where every list (_l) in l gets set in config as :
     config[_l[0]] = {_l[1]: _l[2]}
-    
-    Additionaly some garbage values for parkour API gets set
-    '''
+
+    Additionally some garbage values for parkour API gets set
+    """
     config = configparser.ConfigParser()
-    config['Parkour'] = {
+    config["Parkour"] = {
         "QueryURL": "https://parkour-demo.ie-freiburg.mpg.de/nonext_api",
         "user": "jefke",
         "password": "123",
-        "cert": ""
+        "cert": "",
     }
 
     for _l in l:
         config[_l[0]] = {_l[1]: _l[2]}
 
-    if ( config.get("Options", "sequencerType", fallback="Illumina") != "Aviti" ):
+    if config.get("Options", "sequencerType", fallback="Illumina") != "Aviti":
         if not config.has_option("Options", "runID"):
             config.set("Options", "runID", "150416_SN7001180_0196_BC605HACXX")
     else:
         if not config.has_option("Options", "runID"):
             config.set("Options", "runID", "20250901_AV25XXX9_250443KMND")
-    
+
     return config
+
 
 class TestfindFinishedFlowCells:
     def test_flowCellProcessed(self, ifs):
-        config = create_conf([
-            ['Paths', 'baseData', ifs],
-            ['Options', 'runID', 'fc_fin']
-        ])
+        config = create_conf(
+            [["Paths", "baseData", ifs], ["Options", "runID", "fc_fin"]]
+        )
         assert flowCellProcessed(config) == True
-        config = create_conf([
-            ['Paths', 'baseData', ifs],
-            ['Options', 'runID', 'fc_unfin']
-        ])
+        config = create_conf(
+            [["Paths", "baseData", ifs], ["Options", "runID", "fc_unfin"]]
+        )
         assert flowCellProcessed(config) == False
 
     def test_markFinished(self, ifs):
-        config = create_conf([
-            ['Paths', 'baseData', ifs],
-            ['Options', 'runID', 'fc_unfin'],
-        ])
+        config = create_conf(
+            [
+                ["Paths", "baseData", ifs],
+                ["Options", "runID", "fc_unfin"],
+            ]
+        )
         markFinished(config)
-        assert Path(ifs, 'fc_unfin', 'analysis.done').exists()
+        assert Path(ifs, "fc_unfin", "analysis.done").exists()
 
     def test_queryParkour(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        config = create_conf([
-        ['Paths', 'baseData', ifs],
-        ['Options', 'sequencerType', 'Illumina']])
+        config = create_conf(
+            [["Paths", "baseData", ifs], ["Options", "sequencerType", "Illumina"]]
+        )
         assert len(queryParkour(config)) == 0
 
     ## Sequencing type detection
@@ -77,7 +86,7 @@ class TestfindFinishedFlowCells:
         basedir_path = Path(ifs, "aviti_run")
         seq_type = detect_sequencer_type(str(basedir_path))
         assert seq_type == "Aviti"
-    
+
     def test_typedetection_illumina(self, ifs):
         basedir_path = Path(ifs, "fc_fin")
         seq_type = detect_sequencer_type(str(basedir_path))
@@ -93,18 +102,17 @@ class TestfindFinishedFlowCells:
         mock_resp.json.return_value = {}
         mock_get.return_value = mock_resp
 
-        config = create_conf([
-            ['Paths', 'baseData', ifs],
-            ['Options', 'sequencerType', 'Illumina']
-        ])
+        config = create_conf(
+            [["Paths", "baseData", ifs], ["Options", "sequencerType", "Illumina"]]
+        )
         result = queryParkour(config)
 
         FCID = "C605HACXX"
         mock_get.assert_called_once_with(
             "https://parkour-demo.ie-freiburg.mpg.de/nonext_api",
             auth=("jefke", "123"),
-            params={'flowcell_id': FCID},
-            verify=""
+            params={"flowcell_id": FCID},
+            verify="",
         )
 
         assert result == {}
@@ -118,17 +126,16 @@ class TestfindFinishedFlowCells:
         mock_resp.json.return_value = {"some": "data"}
         mock_get.return_value = mock_resp
 
-        config = create_conf([
-            ['Paths', 'baseData', ifs],
-            ['Options', 'sequencerType', 'Aviti']
-        ])
+        config = create_conf(
+            [["Paths", "baseData", ifs], ["Options", "sequencerType", "Aviti"]]
+        )
         result = queryParkour(config)
 
         FCID = "250443KMND"
         mock_get.assert_called_once_with(
             "https://parkour-demo.ie-freiburg.mpg.de/nonext_api",
             auth=("jefke", "123"),
-            params={'flowcell_id': FCID},
-            verify=""
+            params={"flowcell_id": FCID},
+            verify="",
         )
         assert result == {"some": "data"}


### PR DESCRIPTION
Adds `.pre-commit-config.yaml` based on [maxplanck-ie/template-py](https://github.com/maxplanck-ie/template-py) and hardens the CI workflows.

## Changes
- **`style: apply ruff-format across codebase`** — one-time repo-wide reformat (10 files) now that ruff-format is enforced via pre-commit; also fixes a codespell typo in the findFinishedFlowCells test.
- **`ci: add pre-commit hooks and pin GitHub Actions`**:
  - New `.pre-commit-config.yaml`: pre-commit-hooks, codespell, ruff-check/ruff-format, zizmor. (snakefmt omitted — no Snakemake files here.)
  - All workflow actions pinned to commit SHAs.
  - Least-privilege `permissions:` blocks added to lint/pytest workflows.
  - `persist-credentials: false` on checkout steps.

All hooks pass `pre-commit run --all-files`.