### PR TITLE
ci: Add Dependabot to keep pinned GitHub Actions updated

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Keep GitHub Actions (including the SHA-pinned ones) up to date.
+  # Dependabot bumps the pinned commit SHA and rewrites the `# vX` comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Wait before adopting freshly-published releases (supply-chain hardening).
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Follow-up to #125 (which SHA-pinned all workflow actions). Those pins are now frozen — this adds a Dependabot `github-actions` updater so they stay current automatically.

## What it does
- Monthly checks for new action releases; bumps the pinned commit SHA **and** rewrites the `# vX` comment.
- 7-day `cooldown` before adopting freshly-published releases (supply-chain hardening).
- Groups all action bumps into a single PR with a `chore` commit prefix.

Mirrors the `.github/dependabot.yml` from maxplanck-ie/dissectBCL (PR #274).