### PR TITLE
fix: Scope Aviti detection glob to the current run directory

### DIFF
--- a/BRB/ET.py
+++ b/BRB/ET.py
@@ -255,7 +255,8 @@ def RNA(config, outputDir, baseDict, sample2lib):
 
 def sendToParkour(config, msg):
     basePath = config.get("Paths", "baseData")
-    aviti_check = glob.glob(f"{basePath}/*/RunManifest.csv")
+    runID = config.get("Options", "runID")
+    aviti_check = glob.glob(f"{basePath}/{runID}/RunManifest.csv")
     if aviti_check:
         FCID = config.get("Options", "runID").split("_")[2]
         if "-" in FCID:


### PR DESCRIPTION
## Summary
- `sendToParkour` in `BRB/ET.py` decided whether a run was Aviti by globbing `RunManifest.csv` across the *entire* `baseData` directory, which holds every flowcell on the server, not just the one being processed.
- Because an old Aviti run (`20250918_AV251009_Hepg2-DMSO`) still has a `RunManifest.csv` there, every Illumina run — including `260721_A00931_0931_AHLCC3DRX7_lanes_1` (project `4003_Karayol_Akhtar`) — got misidentified as Aviti and extracted the wrong `flowcell_id` (e.g. `0931` instead of `HLCC3DRX7`).
- Parkour's `/api/sequences_statistics/upload/` endpoint doesn't recognize that ID, so the push 404'd and the run's QC stats never reached Parkour, even though the sequencing/analysis pipeline itself completed fine.
- Fix: scope the glob to the current run's directory (`{basePath}/{runID}/RunManifest.csv`) so detection only depends on the run actually being processed.

## Test plan
- [x] Re-ran `sendToParkour` for `260721_A00931_0931_AHLCC3DRX7_lanes_1` / project `4003_Karayol_Akhtar` — response is `200 {"success":true}` with flowcell_id `HLCC3DRX7`.
- [x] Confirmed a genuine Aviti run (`20250918_AV251009_Hepg2-DMSO`) still resolves `aviti_check` correctly via its own `RunManifest.csv`.
