### PR TITLE
feat: Add -s/--sequencer to restrict polling to one platform's baseData/logPath

### DIFF
--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -58,32 +58,45 @@ def detect_sequencer_type(base_path: str) -> str:
         return "Illumina"
 
 
-def newFlowCell(config):
-    dirs = glob.glob("{}/*/fastq.made".format(config.get("Paths", "baseData")))
-    for d in dirs:
-        # Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)
-        run_id = Path(d).parents[0].name
-        config.set("Options", "runID", run_id)
+def newFlowCell(config, sequencer=None):
+    platforms = []
+    if sequencer in (None, "illumina"):
+        platforms.append(
+            (config.get("Paths", "baseData_illumina"), config.get("Paths", "logPath_illumina"))
+        )
+    if sequencer in (None, "aviti"):
+        platforms.append(
+            (config.get("Paths", "baseData_aviti"), config.get("Paths", "logPath_aviti"))
+        )
 
-        if config.get("Options", "runID")[:4] < "1804":
-            continue
+    for baseData, logPath in platforms:
+        dirs = glob.glob(f"{baseData}/*/fastq.made")
+        for d in dirs:
+            # Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)
+            run_id = Path(d).parents[0].name
+            config.set("Options", "runID", run_id)
 
-        # Detect sequencer type
-        base_path = str(Path(d).parents[0])
-        seq_type = detect_sequencer_type(base_path)
-        config.set("Options", "sequencerType", seq_type)
-
-        if not flowCellProcessed(config):
-            print(
-                f"Found new flow cell: [green]{config.get('Options', 'runID')}[/green]"
-            )
-            # Query parkour to see if there's anything to be done for this
-            ParkourDict = queryParkour(config)
-            if len(ParkourDict) == 0:
-                markFinished(config)
-                config.set("Options", "runID", "")
-                ParkourDict = None
+            if config.get("Options", "runID")[:4] < "1804":
                 continue
-            return config, ParkourDict
+
+            # Detect sequencer type
+            base_path = str(Path(d).parents[0])
+            seq_type = detect_sequencer_type(base_path)
+            config.set("Options", "sequencerType", seq_type)
+            config.set("Paths", "baseData", baseData)
+            config.set("Paths", "logPath", logPath)
+
+            if not flowCellProcessed(config):
+                print(
+                    f"Found new flow cell: [green]{config.get('Options', 'runID')}[/green]"
+                )
+                # Query parkour to see if there's anything to be done for this
+                ParkourDict = queryParkour(config)
+                if len(ParkourDict) == 0:
+                    markFinished(config)
+                    config.set("Options", "runID", "")
+                    ParkourDict = None
+                    continue
+                return config, ParkourDict
     print("No new flow cells found...")
     return config, None

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -62,11 +62,17 @@ def newFlowCell(config, sequencer=None):
     platforms = []
     if sequencer in (None, "illumina"):
         platforms.append(
-            (config.get("Paths", "baseData_illumina"), config.get("Paths", "logPath_illumina"))
+            (
+                config.get("Paths", "baseData_illumina"),
+                config.get("Paths", "logPath_illumina"),
+            )
         )
     if sequencer in (None, "aviti"):
         platforms.append(
-            (config.get("Paths", "baseData_aviti"), config.get("Paths", "logPath_aviti"))
+            (
+                config.get("Paths", "baseData_aviti"),
+                config.get("Paths", "logPath_aviti"),
+            )
         )
 
     for baseData, logPath in platforms:

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -63,6 +63,7 @@ def newFlowCell(config, sequencer=None):
     if sequencer in (None, "illumina"):
         platforms.append(
             (
+                "illumina",
                 config.get("Paths", "baseData_illumina"),
                 config.get("Paths", "logPath_illumina"),
             )
@@ -70,13 +71,16 @@ def newFlowCell(config, sequencer=None):
     if sequencer in (None, "aviti"):
         platforms.append(
             (
+                "aviti",
                 config.get("Paths", "baseData_aviti"),
                 config.get("Paths", "logPath_aviti"),
             )
         )
 
-    for baseData, logPath in platforms:
+    print("Checking for new flowcells...")
+    for platform, baseData, logPath in platforms:
         dirs = glob.glob(f"{baseData}/*/fastq.made")
+        found = False
         for d in dirs:
             # Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)
             run_id = Path(d).parents[0].name
@@ -93,6 +97,7 @@ def newFlowCell(config, sequencer=None):
             config.set("Paths", "logPath", logPath)
 
             if not flowCellProcessed(config):
+                found = True
                 print(
                     f"Found new flow cell: [green]{config.get('Options', 'runID')}[/green]"
                 )
@@ -104,5 +109,6 @@ def newFlowCell(config, sequencer=None):
                     ParkourDict = None
                     continue
                 return config, ParkourDict
-    print("No new flow cells found...")
+        if not found:
+            print(f"  No new {platform} flowcells found.")
     return config, None

--- a/BRB/run.py
+++ b/BRB/run.py
@@ -26,13 +26,21 @@ from BRB.logger import log, setLog
     help="specify a custom ini file.",
     show_default=True,
 )
-def run_brb(configfile):
+@click.option(
+    "-s",
+    "--sequencer",
+    type=click.Choice(["illumina", "aviti"]),
+    required=False,
+    default=None,
+    help="Restrict polling to a single platform's baseData/logPath.",
+)
+def run_brb(configfile, sequencer):
     while True:
         # Read the config file
         config = BRB.getConfig.getConfig(configfile)
 
         # Get the next flow cell to process, or sleep
-        config, ParkourDict = BRB.findFinishedFlowCells.newFlowCell(config)
+        config, ParkourDict = BRB.findFinishedFlowCells.newFlowCell(config, sequencer)
         if (config.get("Options", "runID") == "") or ParkourDict is None:
             sleep(60 * 60)
             continue

--- a/BRB/run.py
+++ b/BRB/run.py
@@ -42,6 +42,7 @@ def run_brb(configfile, sequencer):
         # Get the next flow cell to process, or sleep
         config, ParkourDict = BRB.findFinishedFlowCells.newFlowCell(config, sequencer)
         if (config.get("Options", "runID") == "") or ParkourDict is None:
+            print("Going back to sleep for 60 minutes.")
             sleep(60 * 60)
             continue
 

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -9,6 +9,7 @@ from BRB.findFinishedFlowCells import (
     detect_sequencer_type,
     flowCellProcessed,
     markFinished,
+    newFlowCell,
     queryParkour,
 )
 
@@ -143,3 +144,61 @@ class TestfindFinishedFlowCells:
             verify="",
         )
         assert result == {"some": "data"}
+
+
+@pytest.fixture(scope="session")
+def platform_dirs(tmp_path_factory):
+    fp = tmp_path_factory.mktemp("platform_dirs")
+    illu_base = fp / "illumina"
+    aviti_base = fp / "aviti"
+    (illu_base / "20250101_illumina_runXXX").mkdir(parents=True)
+    (illu_base / "20250101_illumina_runXXX" / "fastq.made").touch()
+    (aviti_base / "20250101_AV999999_runYYY").mkdir(parents=True)
+    (aviti_base / "20250101_AV999999_runYYY" / "fastq.made").touch()
+    return illu_base, aviti_base
+
+
+def create_platform_conf(illu_base, aviti_base):
+    config = configparser.ConfigParser()
+    config["Parkour"] = {
+        "QueryURL": "https://parkour-demo.ie-freiburg.mpg.de/nonext_api",
+        "user": "jefke",
+        "password": "123",
+        "cert": "",
+    }
+    config["Paths"] = {
+        "baseData_illumina": str(illu_base),
+        "baseData_aviti": str(aviti_base),
+        "logPath_illumina": str(illu_base / "LOG"),
+        "logPath_aviti": str(aviti_base / "LOG"),
+    }
+    config["Options"] = {}
+    return config
+
+
+class TestNewFlowCellSequencerGating:
+    @patch("BRB.findFinishedFlowCells.queryParkour")
+    def test_illumina_only_never_touches_aviti(self, mock_query, platform_dirs):
+        illu_base, aviti_base = platform_dirs
+        mock_query.return_value = {"some": "data"}
+        config = create_platform_conf(illu_base, aviti_base)
+
+        config, ParkourDict = newFlowCell(config, sequencer="illumina")
+
+        assert config.get("Options", "runID") == "20250101_illumina_runXXX"
+        assert config.get("Paths", "baseData") == str(illu_base)
+        assert config.get("Paths", "logPath") == str(illu_base / "LOG")
+        assert not Path(aviti_base, "20250101_AV999999_runYYY", "analysis.done").exists()
+
+    @patch("BRB.findFinishedFlowCells.queryParkour")
+    def test_aviti_only_never_touches_illumina(self, mock_query, platform_dirs):
+        illu_base, aviti_base = platform_dirs
+        mock_query.return_value = {"some": "data"}
+        config = create_platform_conf(illu_base, aviti_base)
+
+        config, ParkourDict = newFlowCell(config, sequencer="aviti")
+
+        assert config.get("Options", "runID") == "20250101_AV999999_runYYY"
+        assert config.get("Paths", "baseData") == str(aviti_base)
+        assert config.get("Paths", "logPath") == str(aviti_base / "LOG")
+        assert not Path(illu_base, "20250101_illumina_runXXX", "analysis.done").exists()

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -183,7 +183,7 @@ class TestNewFlowCellSequencerGating:
         mock_query.return_value = {"some": "data"}
         config = create_platform_conf(illu_base, aviti_base)
 
-        config, ParkourDict = newFlowCell(config, sequencer="illumina")
+        config, _ = newFlowCell(config, sequencer="illumina")
 
         assert config.get("Options", "runID") == "20250101_illumina_runXXX"
         assert config.get("Paths", "baseData") == str(illu_base)
@@ -198,7 +198,7 @@ class TestNewFlowCellSequencerGating:
         mock_query.return_value = {"some": "data"}
         config = create_platform_conf(illu_base, aviti_base)
 
-        config, ParkourDict = newFlowCell(config, sequencer="aviti")
+        config, _ = newFlowCell(config, sequencer="aviti")
 
         assert config.get("Options", "runID") == "20250101_AV999999_runYYY"
         assert config.get("Paths", "baseData") == str(aviti_base)

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -188,7 +188,9 @@ class TestNewFlowCellSequencerGating:
         assert config.get("Options", "runID") == "20250101_illumina_runXXX"
         assert config.get("Paths", "baseData") == str(illu_base)
         assert config.get("Paths", "logPath") == str(illu_base / "LOG")
-        assert not Path(aviti_base, "20250101_AV999999_runYYY", "analysis.done").exists()
+        assert not Path(
+            aviti_base, "20250101_AV999999_runYYY", "analysis.done"
+        ).exists()
 
     @patch("BRB.findFinishedFlowCells.queryParkour")
     def test_aviti_only_never_touches_illumina(self, mock_query, platform_dirs):


### PR DESCRIPTION
## Summary
- Mirrors the same change just made in dissectBCL: `Paths.baseData`/`logPath` split into per-platform `baseData_illumina`/`baseData_aviti` and `logPath_illumina`/`logPath_aviti`.
- `run_brb` gains `-s/--sequencer {illumina,aviti}`; `newFlowCell()` takes an optional sequencer filter and, once a flowcell matches, writes the matched platform's `baseData`/`logPath` back into `config["Paths"]` so every downstream reader (`ET.py`, `PushButton.py`, `flowCellProcessed`, `markFinished`, `run.py`) keeps working unchanged.
- Lets `brb_illu`/`brb_aviti` share one config file, differing only by `-s`, instead of two near-duplicate files.

## Test plan
- [x] `pytest tests/` — 16/16 passing, including new tests asserting `-s illumina`/`-s aviti` never touch the other platform's directory.
- [x] Deployed on rapidus (editable `BRB` conda env), verified `BigRedButton --help` shows the new option.