### PR TITLE
feat: process external RELACS ChIP-Seq and fix RELACS QC-sharing bugs

### DIFF
--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -187,28 +187,24 @@ def copyCellRanger(config, d, ignore=False):
         shutil.copyfile(fname, bioinfoCoreDirPath)
 
 
-def copyRELACS(config, d, ignore=False):
+def copyRELACS(config, d):
     """
     copy RELACS demultiplexing png files to sequencing facility lane subdirectory.
     e.g. /seqFacDir/Sequence_Quality_yyyy/Illumina_yyyy/flowcell_xxxx_lane_1/xxx_RELACS_sample_fig.png
 
-    Skipped entirely when `ignore` is true (external/non-PI project), since
-    both destinations are internal-only.
+    Runs the same for internal and external (non-PI) projects: the
+    sequencing facility (seqFacDir) and bioinfo-core (bioinfoCoreDir) QC
+    diagnostics for a RELACS run are shared regardless of who owns the
+    project, unlike the raw/processed data itself.
 
           :params config: configuration parsed from .ini file
           :params d: path to subdirectory of analysis folder, .e.g.
           /data/xxx/sequencing_data/yyyy_lanes_1/Analysis_2526_zzzz/ChIP-Seq_bla/RELACS_demultiplexing
-          :params ignore: whether this is an external/non-PI project
           :type config: configparser.ConfigParser
           :type d: str
-          :type ignore: bool
           :return: None
           :rtype: None
     """
-    if ignore:
-        log.info(f"Skipping copyRELACS for external project under {d}.")
-        return
-
     files = glob.glob(
         os.path.join(d, "RELACS_demultiplexing", "Sample*/", "*_fig.png")
     ) + glob.glob(os.path.join(d, "multiQC", "*html"))
@@ -233,8 +229,13 @@ def copyRELACS(config, d, ignore=False):
             Path(config.get("Paths", "seqFacDir")) / year_postfix / lane_dir
         )
         os.makedirs(seqfac_lane_dir, exist_ok=True)
-        nname = seqfac_lane_dir / nname
+        # bname must be computed from the plain (relative) nname, before it's
+        # turned into an absolute seqFacDir path below -- Path(a) / b drops
+        # `a` entirely when `b` is already absolute, which previously made
+        # this silently re-copy to the seqFacDir path a second time instead
+        # of ever reaching bioinfoCoreDir.
         bname = Path(config.get("Paths", "bioinfoCoreDir")) / nname
+        nname = seqfac_lane_dir / nname
         shutil.copyfile(fname, nname)
         shutil.copyfile(fname, bname)
 
@@ -465,7 +466,7 @@ def RELACS(config, group, project, organism, libraryType, tuples):
         return outputDir, 1, False
     removeLinkFiles(outputDir)
     tidyUpABit(outputDir)
-    copyRELACS(config, outputDir, ignore)
+    copyRELACS(config, outputDir)
     # Recreate links under originalFastQ
     for fname in glob.glob(
         os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")

--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -10,6 +10,25 @@ import BRB.misc
 from BRB.logger import log
 
 
+def parseExternalAllowlist(configValue):
+    """Split a comma-separated ini value into a clean list of entries."""
+    return [x.strip() for x in configValue.split(",") if x.strip()]
+
+
+def isExternallyAllowed(
+    libraryType, libraryProtocol, externalLibraryTypes, externalLibraryProtocols
+):
+    """
+    Whether a sample should still be processed for an external (non-PI)
+    project, based on its Parkour library type (exact match against
+    externalLibraryTypes) or library protocol (startswith match against
+    externalLibraryProtocols).
+    """
+    if libraryType in externalLibraryTypes:
+        return True
+    return any(libraryProtocol.startswith(p) for p in externalLibraryProtocols)
+
+
 def createPath(config, group, project, org_label, libraryType, tuples):
     """Ensures that the output path exists, creates it otherwise, and return where it is"""
     if tuples[0][3]:
@@ -81,12 +100,18 @@ def removeLinkFiles(d):
 def relinkFiles(config, group, project, org_label, libraryType, tuples):
     """
     Generate symlinks under the snakepipes originalFASTQ folder directly from the project folder.
-    At this stage the multiqc files are copied over into the bioinfocoredir, as well.
+    At this stage the multiqc files are copied over into the bioinfocoredir, as well
+    (skipped for external/ignored projects, since bioinfoCoreDir is internal-only).
     """
     # relink fqs
     outputDir = createPath(config, group, project, org_label, libraryType, tuples)
     odir = os.path.join(outputDir, "originalFASTQ")
     linkFiles(config, group, project, odir, tuples)
+    if tuples[0][3]:
+        log.info(
+            f"Skipping bioinfoCoreDir multiqc copy for external project {project}."
+        )
+        return
     # Copy mqc
     mqcf = os.path.join(outputDir, "multiQC", "multiqc_report.html")
     if os.path.exists(mqcf):
@@ -113,19 +138,27 @@ def getsambaPath(lane_dir, Sequencer):
     return current_year, year_postfix
 
 
-def copyCellRanger(config, d):
+def copyCellRanger(config, d, ignore=False):
     """
     copy Cellranger web_summaries to sequencing facility lane subdirectory & bioinfocore qc directory.
     e.g. /seqFacDir/Sequence_Quality_yyyy/Illumina_yyyy/flowcell_xxxx_lane_1/Analysis_xxx_sample_web_summary.html
 
+    Skipped entirely when `ignore` is true (external/non-PI project), since
+    both destinations are internal-only.
+
           :params config: configuration parsed from .ini file
           :params d: path to subdirectory of analysis folder, .e.g.
           /data/xxx/sequencing_data/yyyy_lanes_1/Analysis_2526_zzzz/RNA-Seq
+          :params ignore: whether this is an external/non-PI project
           :type config: configparser.ConfigParser
           :type d: str
+          :type ignore: bool
           :return: None
           :rtype: None
     """
+    if ignore:
+        log.info(f"Skipping copyCellRanger for external project under {d}.")
+        return
 
     files = glob.glob(os.path.join(d, "*/outs/", "web_summary.html"))
     sequencing_type = config.get("Options", "sequencerType")
@@ -154,19 +187,27 @@ def copyCellRanger(config, d):
         shutil.copyfile(fname, bioinfoCoreDirPath)
 
 
-def copyRELACS(config, d):
+def copyRELACS(config, d, ignore=False):
     """
     copy RELACS demultiplexing png files to sequencing facility lane subdirectory.
     e.g. /seqFacDir/Sequence_Quality_yyyy/Illumina_yyyy/flowcell_xxxx_lane_1/xxx_RELACS_sample_fig.png
 
+    Skipped entirely when `ignore` is true (external/non-PI project), since
+    both destinations are internal-only.
+
           :params config: configuration parsed from .ini file
           :params d: path to subdirectory of analysis folder, .e.g.
           /data/xxx/sequencing_data/yyyy_lanes_1/Analysis_2526_zzzz/ChIP-Seq_bla/RELACS_demultiplexing
+          :params ignore: whether this is an external/non-PI project
           :type config: configparser.ConfigParser
           :type d: str
+          :type ignore: bool
           :return: None
           :rtype: None
     """
+    if ignore:
+        log.info(f"Skipping copyRELACS for external project under {d}.")
+        return
 
     files = glob.glob(
         os.path.join(d, "RELACS_demultiplexing", "Sample*/", "*_fig.png")
@@ -293,17 +334,25 @@ def RELACS(config, group, project, organism, libraryType, tuples):
     runID = config.get("Options", "runID").split("_lanes")[0]
     sequencerType = config.get("Options", "sequencerType")
     _org_name, org_label, org_yaml = organism
+    ignore = tuples[0][3]
     outputDir = createPath(
         config, group, BRB.misc.pacifier(project), org_label, libraryType, tuples
     )
     if os.path.exists(os.path.join(outputDir, "analysis.done")):
+        if ignore and not os.path.exists(
+            os.path.join(outputDir, "external_delivery.done")
+        ):
+            deliverExternalRELACS(config, outputDir, BRB.misc.pacifier(project))
         return outputDir, 0, True
 
     project = BRB.misc.pacifier(project)
 
     if sequencerType == "Aviti":
+        # short_runs nests an extra instrument-id directory between the
+        # sequencer prefix and the run itself, e.g.
+        # short_runs/AVITI/AV251009/<runID>/RELACS_Project_<project>.txt
         matches = glob.glob(
-            f"/dont_touch_this/short_runs/AV*/{runID}/RELACS_Project_{project}.txt"
+            f"/dont_touch_this/short_runs/AV*/AV*/{runID}/RELACS_Project_{project}.txt"
         )
         sampleSheet = matches[0] if matches else None
     else:
@@ -312,19 +361,30 @@ def RELACS(config, group, project, organism, libraryType, tuples):
         )
 
     # Fallback if exact path doesn't exist
-    if not os.path.exists(sampleSheet) and not os.path.exists(
-        os.path.join(outputDir, "RELACS_sampleSheet.txt")
+    if not sampleSheet or (
+        not os.path.exists(sampleSheet)
+        and not os.path.exists(os.path.join(outputDir, "RELACS_sampleSheet.txt"))
     ):
         log.critical(f"RELACS: wrong samplesheet name: {sampleSheet}")
         return None, 1, False
 
-    baseDir = "{}/{}/{}/{}/Project_{}".format(
-        config.get("Paths", "groupData"),
-        BRB.misc.pacifier(group),
-        BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
-        config.get("Options", "runID"),
-        project,
-    )
+    if ignore:
+        # External (non-PI) project: the raw pooled Sample_* directories
+        # live directly under baseData/runID/Project_{project}, since there's
+        # no PI group directory under groupData for an external user.
+        baseDir = "{}/{}/Project_{}".format(
+            config.get("Paths", "baseData"),
+            config.get("Options", "runID"),
+            project,
+        )
+    else:
+        baseDir = "{}/{}/{}/{}/Project_{}".format(
+            config.get("Paths", "groupData"),
+            BRB.misc.pacifier(group),
+            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+            config.get("Options", "runID"),
+            project,
+        )
 
     # Link in files
     if not os.path.exists(os.path.join(outputDir, "RELACS_sampleSheet.txt")):
@@ -405,7 +465,7 @@ def RELACS(config, group, project, organism, libraryType, tuples):
         return outputDir, 1, False
     removeLinkFiles(outputDir)
     tidyUpABit(outputDir)
-    copyRELACS(config, outputDir)
+    copyRELACS(config, outputDir, ignore)
     # Recreate links under originalFastQ
     for fname in glob.glob(
         os.path.join(outputDir, "RELACS_demultiplexing", "*", "*.gz")
@@ -419,7 +479,71 @@ def RELACS(config, group, project, organism, libraryType, tuples):
         os.symlink(fname, newName)
     stripRights(outputDir)
     touchDone(outputDir)
+    if ignore:
+        deliverExternalRELACS(config, outputDir, project)
     return outputDir, 0, True
+
+
+def deliverExternalRELACS(config, outputDir, project):
+    """
+    For external (non-PI) RELACS projects: once the pipeline has succeeded,
+    reclaim space by truncating the bulky, fully-reproducible intermediate
+    FASTQs (RELACS_demultiplexing/, FASTQ_Cutadapt/), then package the real
+    result files (BAMs, bigwigs, multiQC, and run metadata -- no symlinks,
+    no intermediates) into a tar.gz and deliver it via fexsend to the
+    configured recipient.
+
+    Guarded by a separate external_delivery.done marker (distinct from
+    analysis.done), so if this step is interrupted after the pipeline itself
+    succeeded, the next poll retries delivery instead of the outer
+    analysis.done check silently skipping it forever.
+
+    Failure here is logged but non-fatal: the analysis itself already
+    succeeded, and delivery can be retried on the next poll or by hand.
+    """
+    doneMarker = os.path.join(outputDir, "external_delivery.done")
+    if os.path.exists(doneMarker):
+        return
+    try:
+        for subdir in ("RELACS_demultiplexing", "FASTQ_Cutadapt"):
+            pattern = os.path.join(outputDir, subdir, "**", "*.gz")
+            for fname in glob.glob(pattern, recursive=True):
+                open(fname, "w").close()
+
+        includeNames = ["Bowtie2", "filtered_bam", "bamCoverage", "multiQC"]
+        for fname in sorted(os.listdir(outputDir)):
+            full = os.path.join(outputDir, fname)
+            if os.path.islink(full) or not os.path.isfile(full):
+                continue
+            if fname.endswith((".config.yaml", "_organism.yaml")) or (
+                fname == "RELACS_sampleSheet.txt"
+            ):
+                includeNames.append(fname)
+        includeNames = [
+            n for n in includeNames if os.path.exists(os.path.join(outputDir, n))
+        ]
+
+        archiveName = f"Analysis_{project}.tar.gz"
+        fexBin = os.path.expanduser(
+            config.get("external", "fexsendBin", fallback="fexsend")
+        )
+        fexRecipient = config.get("external", "fexRecipient", fallback="")
+        comment = f"BRB external delivery: project {project}"
+        CMD = "tar -czf - {} | {} -s {} -C '{}' {}".format(
+            " ".join(includeNames),
+            fexBin,
+            archiveName,
+            comment,
+            fexRecipient,
+        )
+        log.info(f"External delivery CMD: {CMD}")
+        subprocess.check_call(CMD, shell=True, cwd=outputDir)
+        open(doneMarker, "w").close()
+    except:
+        log.error(
+            f"External delivery failed for {outputDir}; the analysis itself "
+            "succeeded, delivery will be retried on the next poll."
+        )
 
 
 def DNA(config, group, project, organism, libraryType, tuples):
@@ -616,7 +740,7 @@ def scRNAseq(config, group, project, organism, libraryType, tuples):
         removeLinkFiles(outputDir)
         tidyUpABit(outputDir)
         stripRights(outputDir)
-        copyCellRanger(config, outputDir)
+        copyCellRanger(config, outputDir, tuples[0][3])
         sambaUpdate = True
     elif tuples[0][2] == "Cel-Seq 2 for single cell RNA-Seq":
         PE = linkFiles(config, group, project, outputDir, tuples)
@@ -743,13 +867,21 @@ def scATAC(config, group, project, organism, libraryType, tuples):
     ):
         # PE = linkFiles(config, group, project, outputDir, tuples)
         samples = " ".join(i[1] for i in tuples)
-        inDir = "{}/{}/{}/{}/Project_{}".format(
-            config.get("Paths", "groupData"),
-            BRB.misc.pacifier(group),
-            BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
-            config.get("Options", "runID"),
-            BRB.misc.pacifier(project),
-        )
+        if tuples[0][3]:
+            # External (non-PI) project: no group directory under groupData.
+            inDir = "{}/{}/Project_{}".format(
+                config.get("Paths", "baseData"),
+                config.get("Options", "runID"),
+                BRB.misc.pacifier(project),
+            )
+        else:
+            inDir = "{}/{}/{}/{}/Project_{}".format(
+                config.get("Paths", "groupData"),
+                BRB.misc.pacifier(group),
+                BRB.misc.getLatestSeqdir(config.get("Paths", "groupData"), group),
+                config.get("Options", "runID"),
+                BRB.misc.pacifier(project),
+            )
 
         snakeMakePath = "{}/bin".format(
             os.path.join(config.get("Options", "snakemakeWorkflowBaseDir"))
@@ -766,7 +898,7 @@ def scATAC(config, group, project, organism, libraryType, tuples):
         except:
             return outputDir, 1, False
         # removeLinkFiles(outputDir)
-        copyCellRanger(config, outputDir)
+        copyCellRanger(config, outputDir, tuples[0][3])
         stripRights(outputDir)
         tidyUpABit(outputDir)
     else:
@@ -811,6 +943,16 @@ def GetResults(config, project, libraries):
         for i, v in enumerate(config.get("Options", "validLibraryTypes").split(","))
     }
     pipelines = config.get("Options", "pipelines").split(",")
+    # Library types/protocols that should still be processed for external
+    # (non-PI) projects. Split into real lists up front: `x in "a,b,c"`
+    # would otherwise do substring matching against the raw config string
+    # (e.g. "RNA-Seq" would false-positive against "stranded mRNA-Seq").
+    externalLibraryTypes = parseExternalAllowlist(
+        config.get("external", "LibraryTypes", fallback="")
+    )
+    externalLibraryProtocols = parseExternalAllowlist(
+        config.get("external", "LibraryProtocols", fallback="")
+    )
     # split by analysis type and species, since we can only process some types of this
     analysisTypes = {}
     skipList = []
@@ -835,12 +977,13 @@ def GetResults(config, project, libraries):
             log.info(
                 f"Species label or YAML was not set for {org_name} (check Parkour DB.)"
             )
+        externallyAllowed = isExternallyAllowed(
+            libraryType, libraryProtocol, externalLibraryTypes, externalLibraryProtocols
+        )
         if (
             libraryType in validLibraryTypes
             and (org_label or org_yaml)
-            and (
-                ignore == False or libraryType in config.get("external", "LibraryTypes")
-            )
+            and (ignore == False or externallyAllowed)
         ):
             if org_label not in org_dict:
                 org_dict[org_label] = organism

--- a/BigRedButton.ini
+++ b/BigRedButton.ini
@@ -60,4 +60,25 @@ ATAC=/path/to/repo/10X_snakepipe/10x_scATAC/10x_scATAC
 
 
 [external]
+# Projects that don't belong to any PI/group under $groupData (e.g. external
+# collaborators) are skipped by default, regardless of library type. The two
+# settings below opt specific libraries back in for processing anyway; their
+# output goes under $baseData/<runID>/Analysis_<project>/ instead of a PI's
+# groupData tree, since there's no group directory to put it in.
+#
+# Library types (comma separated) that should still be processed for
+# external projects. Matched against the Parkour "library type" field (see
+# validLibraryTypes above).
 LibraryTypes =
+# Library protocols (comma separated) that should still be processed for
+# external projects, matched via startswith() against the Parkour "library
+# protocol" field. Use this for protocol-specific opt-ins (e.g. "ChIP RELACS
+# high-throughput") without opening up every library of that type to
+# external processing.
+LibraryProtocols =
+# Where BRB fexsends the final results tarball for external projects
+# processed via LibraryTypes/LibraryProtocols above (currently only used by
+# the RELACS pipeline).
+fexRecipient = mustermann@ie-freiburg.mpg.de
+# Path to the fexsend binary used for the above.
+fexsendBin = ~/.local/bin/fexsend

--- a/tests/test_PushButton.py
+++ b/tests/test_PushButton.py
@@ -110,11 +110,15 @@ class TestIsExternallyAllowed:
 
 class TestInternalShareSkip:
     """
-    copyCellRanger/copyRELACS read config['Paths']['seqFacDir'] and
-    ['bioinfoCoreDir'] as soon as they proceed past the ignore check. A
-    config missing those keys makes that a hard failure, which we use here
-    to prove the functions return immediately (without touching them) when
-    ignore=True, and do NOT return early when ignore=False.
+    copyCellRanger reads config['Paths']['seqFacDir'] and ['bioinfoCoreDir']
+    as soon as it proceeds past the ignore check. A config missing those
+    keys makes that a hard failure, which we use here to prove the function
+    returns immediately (without touching them) when ignore=True, and does
+    NOT return early when ignore=False.
+
+    copyRELACS has no such skip: RELACS QC diagnostics (seqFacDir +
+    bioinfoCoreDir) are shared for internal and external projects alike, see
+    TestCopyRELACSAlwaysRuns below.
     """
 
     def test_copyCellRanger_skips_when_ignored(self, tmp_path):
@@ -131,21 +135,6 @@ class TestInternalShareSkip:
         with pytest.raises(configparser.NoSectionError):
             copyCellRanger(config, str(tmp_path), ignore=False)
 
-    def test_copyRELACS_skips_when_ignored(self, tmp_path):
-        config = configparser.ConfigParser()
-        config["Options"] = {"sequencerType": "Aviti"}
-        copyRELACS(config, str(tmp_path), ignore=True)
-
-    def test_copyRELACS_raises_when_not_ignored_and_misconfigured(self, tmp_path):
-        config = configparser.ConfigParser()
-        config["Options"] = {"sequencerType": "Aviti"}
-        (tmp_path / "RELACS_demultiplexing" / "Sample1").mkdir(parents=True)
-        (tmp_path / "RELACS_demultiplexing" / "Sample1" / "mark_fig.png").write_text(
-            "x"
-        )
-        with pytest.raises(configparser.NoSectionError):
-            copyRELACS(config, str(tmp_path), ignore=False)
-
     def test_relinkFiles_skips_mqc_copy_when_ignored(self, tmp_path):
         config = configparser.ConfigParser()
         config["Paths"] = {"baseData": str(tmp_path), "groupData": str(tmp_path)}
@@ -155,6 +144,55 @@ class TestInternalShareSkip:
         # missing bioinfoCoreDir key.
         tuples = [["lib1", "sample1", "protocol", True]]
         PushButton.relinkFiles(config, "group", "proj", "org", "ChIP-Seq", tuples)
+
+
+class TestCopyRELACSAlwaysRuns:
+    """
+    copyRELACS() takes no `ignore` param and ships the same seqFacDir +
+    bioinfoCoreDir QC diagnostics regardless of whether the project is
+    internal or external -- unlike copyCellRanger, which is still skipped
+    for external projects.
+    """
+
+    def _make_output_dir(self, tmp_path):
+        outputDir = (
+            tmp_path
+            / "20260101_AV999999_1234567_lanes_1_2"
+            / "Analysis_99_Foo_Bar"
+            / "ChIP-Seq_h38"
+        )
+        (outputDir / "RELACS_demultiplexing" / "Sample_1").mkdir(parents=True)
+        (outputDir / "RELACS_demultiplexing" / "Sample_1" / "mark_fig.png").write_text(
+            "x"
+        )
+        (outputDir / "multiQC").mkdir(parents=True)
+        (outputDir / "multiQC" / "multiqc_report.html").write_text("x")
+        return outputDir
+
+    def test_copies_to_seqfac_and_bioinfocore(self, tmp_path):
+        outputDir = self._make_output_dir(tmp_path)
+        seqfac = tmp_path / "seqfac"
+        bioinfocore = tmp_path / "bioinfocore"
+        bioinfocore.mkdir()
+        config = make_config(
+            overrides={
+                "Paths": {"seqFacDir": str(seqfac), "bioinfoCoreDir": str(bioinfocore)}
+            }
+        )
+
+        copyRELACS(config, str(outputDir))
+
+        seqfac_files = list(seqfac.rglob("*"))
+        assert any(f.name.endswith("mark_fig.png") for f in seqfac_files)
+        assert any(f.name.endswith("RELACS_analysis.html") for f in seqfac_files)
+        bioinfocore_files = list(bioinfocore.iterdir())
+        assert any(f.name.endswith("mark_fig.png") for f in bioinfocore_files)
+        assert any(f.name.endswith("RELACS_analysis.html") for f in bioinfocore_files)
+
+    def test_no_ignore_param_accepted(self):
+        import inspect
+
+        assert "ignore" not in inspect.signature(copyRELACS).parameters
 
 
 class TestDeliverExternalRELACS:
@@ -268,11 +306,18 @@ class TestRELACSExternalPaths:
         return config, tuples, project, outputDir, sampleSheetContent
 
     @patch("BRB.PushButton.createPath")
+    @patch("BRB.PushButton.copyRELACS")
     @patch("BRB.PushButton.deliverExternalRELACS")
     @patch("BRB.PushButton.subprocess.check_call")
     @patch("BRB.PushButton.glob.glob")
     def test_external_uses_baseData_not_groupData(
-        self, mock_glob, mock_check_call, mock_deliver, mock_createPath, tmp_path
+        self,
+        mock_glob,
+        mock_check_call,
+        mock_deliver,
+        mock_copyRELACS,
+        mock_createPath,
+        tmp_path,
     ):
         config, tuples, project, outputDir, sheetContent = self._base_setup(
             tmp_path, ignore=True

--- a/tests/test_PushButton.py
+++ b/tests/test_PushButton.py
@@ -1,0 +1,373 @@
+import configparser
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from BRB import PushButton
+from BRB.PushButton import (
+    RELACS,
+    copyCellRanger,
+    copyRELACS,
+    deliverExternalRELACS,
+    isExternallyAllowed,
+    parseExternalAllowlist,
+)
+
+
+def make_config(overrides=None):
+    """
+    Minimal config with just enough set for the functions under test.
+    `overrides` is a dict of {section: {key: value}}.
+    """
+    config = configparser.ConfigParser()
+    config["Paths"] = {
+        "baseData": "/base",
+        "groupData": "/data",
+        "seqFacDir": "/seqfac",
+        "bioinfoCoreDir": "/bioinfocore",
+    }
+    config["Options"] = {
+        "runID": "20260101_AV999999_1234567_lanes_1_2",
+        "sequencerType": "Aviti",
+        "snakemakeWorkflowBaseDir": "/snakepipes",
+    }
+    config["external"] = {
+        "LibraryTypes": "",
+        "LibraryProtocols": "",
+        "fexRecipient": "pipegrp@example.org",
+        "fexsendBin": "/fex/fexsend",
+    }
+    for section, kv in (overrides or {}).items():
+        if section not in config:
+            config[section] = {}
+        config[section].update(kv)
+    return config
+
+
+class TestParseExternalAllowlist:
+    def test_empty_string(self):
+        assert parseExternalAllowlist("") == []
+
+    def test_single_entry(self):
+        assert parseExternalAllowlist("ChIP-Seq") == ["ChIP-Seq"]
+
+    def test_multiple_entries_stripped(self):
+        assert parseExternalAllowlist("ChIP-Seq, RNA-Seq ,WGS") == [
+            "ChIP-Seq",
+            "RNA-Seq",
+            "WGS",
+        ]
+
+    def test_ignores_blank_entries(self):
+        assert parseExternalAllowlist("ChIP-Seq,,  ,RNA-Seq") == [
+            "ChIP-Seq",
+            "RNA-Seq",
+        ]
+
+
+class TestIsExternallyAllowed:
+    def test_exact_type_match(self):
+        assert isExternallyAllowed("ChIP-Seq", "anything", ["ChIP-Seq"], []) is True
+
+    def test_no_match(self):
+        assert isExternallyAllowed("RNA-Seq", "anything", ["ChIP-Seq"], []) is False
+
+    def test_protocol_startswith_match(self):
+        assert (
+            isExternallyAllowed(
+                "ChIP-Seq",
+                "ChIP RELACS high-throughput v2",
+                [],
+                ["ChIP RELACS high-throughput"],
+            )
+            is True
+        )
+
+    def test_protocol_no_match(self):
+        assert (
+            isExternallyAllowed(
+                "ChIP-Seq", "Standard ChIP-Seq", [], ["ChIP RELACS high-throughput"]
+            )
+            is False
+        )
+
+    def test_no_substring_false_positive(self):
+        """
+        Regression test: `libraryType in "a,b,c"` (the old code) does
+        substring matching against the raw string, so "RNA-Seq" would
+        false-positive against "stranded mRNA-Seq". With real list
+        membership, it must not.
+        """
+        assert (
+            isExternallyAllowed("stranded mRNA-Seq", "anything", ["RNA-Seq"], [])
+            is False
+        )
+
+    def test_empty_allowlists(self):
+        assert isExternallyAllowed("ChIP-Seq", "ChIP RELACS", [], []) is False
+
+
+class TestInternalShareSkip:
+    """
+    copyCellRanger/copyRELACS read config['Paths']['seqFacDir'] and
+    ['bioinfoCoreDir'] as soon as they proceed past the ignore check. A
+    config missing those keys makes that a hard failure, which we use here
+    to prove the functions return immediately (without touching them) when
+    ignore=True, and do NOT return early when ignore=False.
+    """
+
+    def test_copyCellRanger_skips_when_ignored(self, tmp_path):
+        config = configparser.ConfigParser()
+        config["Options"] = {"sequencerType": "Aviti"}
+        # No [Paths] section at all -- would raise if the function proceeded.
+        copyCellRanger(config, str(tmp_path), ignore=True)
+
+    def test_copyCellRanger_raises_when_not_ignored_and_misconfigured(self, tmp_path):
+        config = configparser.ConfigParser()
+        config["Options"] = {"sequencerType": "Aviti"}
+        (tmp_path / "sampleA" / "outs").mkdir(parents=True)
+        (tmp_path / "sampleA" / "outs" / "web_summary.html").write_text("x")
+        with pytest.raises(configparser.NoSectionError):
+            copyCellRanger(config, str(tmp_path), ignore=False)
+
+    def test_copyRELACS_skips_when_ignored(self, tmp_path):
+        config = configparser.ConfigParser()
+        config["Options"] = {"sequencerType": "Aviti"}
+        copyRELACS(config, str(tmp_path), ignore=True)
+
+    def test_copyRELACS_raises_when_not_ignored_and_misconfigured(self, tmp_path):
+        config = configparser.ConfigParser()
+        config["Options"] = {"sequencerType": "Aviti"}
+        (tmp_path / "RELACS_demultiplexing" / "Sample1").mkdir(parents=True)
+        (tmp_path / "RELACS_demultiplexing" / "Sample1" / "mark_fig.png").write_text(
+            "x"
+        )
+        with pytest.raises(configparser.NoSectionError):
+            copyRELACS(config, str(tmp_path), ignore=False)
+
+    def test_relinkFiles_skips_mqc_copy_when_ignored(self, tmp_path):
+        config = configparser.ConfigParser()
+        config["Paths"] = {"baseData": str(tmp_path), "groupData": str(tmp_path)}
+        config["Options"] = {"runID": "run1"}
+        # tuples[0][3] = True (ignore); createPath/linkFiles will run fine
+        # under baseData, but if the mqc-copy step ran it would raise on the
+        # missing bioinfoCoreDir key.
+        tuples = [["lib1", "sample1", "protocol", True]]
+        PushButton.relinkFiles(config, "group", "proj", "org", "ChIP-Seq", tuples)
+
+
+class TestDeliverExternalRELACS:
+    def _make_output_dir(self, tmp_path):
+        outputDir = tmp_path / "Analysis_99_Foo_Bar" / "ChIP-Seq_h38"
+        outputDir.mkdir(parents=True)
+        (outputDir / "RELACS_demultiplexing" / "Sample_1").mkdir(parents=True)
+        (
+            outputDir / "RELACS_demultiplexing" / "Sample_1" / "a_R1.fastq.gz"
+        ).write_bytes(b"not actually empty")
+        (outputDir / "FASTQ_Cutadapt").mkdir()
+        (outputDir / "FASTQ_Cutadapt" / "a_R1.fastq.gz").write_bytes(b"also not empty")
+        (outputDir / "Bowtie2").mkdir()
+        (outputDir / "Bowtie2" / "a.bam").write_bytes(b"bam")
+        (outputDir / "filtered_bam").mkdir()
+        (outputDir / "bamCoverage").mkdir()
+        (outputDir / "multiQC").mkdir()
+        (outputDir / "DNAmapping.config.yaml").write_text("x: 1")
+        (outputDir / "RELACS_sampleSheet.txt").write_text("a\tb\tc")
+        return outputDir
+
+    def test_truncates_intermediate_gz_files(self, tmp_path):
+        outputDir = self._make_output_dir(tmp_path)
+        config = make_config()
+        with patch("BRB.PushButton.subprocess.check_call") as mock_call:
+            deliverExternalRELACS(config, str(outputDir), "99_Foo_Bar")
+        assert mock_call.called
+        gz1 = outputDir / "RELACS_demultiplexing" / "Sample_1" / "a_R1.fastq.gz"
+        gz2 = outputDir / "FASTQ_Cutadapt" / "a_R1.fastq.gz"
+        assert gz1.stat().st_size == 0
+        assert gz2.stat().st_size == 0
+
+    def test_tar_command_includes_expected_dirs_and_excludes_intermediates(
+        self, tmp_path
+    ):
+        outputDir = self._make_output_dir(tmp_path)
+        config = make_config()
+        with patch("BRB.PushButton.subprocess.check_call") as mock_call:
+            deliverExternalRELACS(config, str(outputDir), "99_Foo_Bar")
+        cmd = mock_call.call_args[0][0]
+        assert "Bowtie2" in cmd
+        assert "filtered_bam" in cmd
+        assert "bamCoverage" in cmd
+        assert "multiQC" in cmd
+        assert "DNAmapping.config.yaml" in cmd
+        assert "RELACS_sampleSheet.txt" in cmd
+        assert "RELACS_demultiplexing" not in cmd
+        assert "FASTQ_Cutadapt" not in cmd
+        assert "/fex/fexsend" in cmd
+        assert "pipegrp@example.org" in cmd
+        assert "Analysis_99_Foo_Bar.tar.gz" in cmd
+
+    def test_creates_done_marker_on_success(self, tmp_path):
+        outputDir = self._make_output_dir(tmp_path)
+        config = make_config()
+        with patch("BRB.PushButton.subprocess.check_call"):
+            deliverExternalRELACS(config, str(outputDir), "99_Foo_Bar")
+        assert (outputDir / "external_delivery.done").exists()
+
+    def test_second_call_is_a_noop(self, tmp_path):
+        outputDir = self._make_output_dir(tmp_path)
+        (outputDir / "external_delivery.done").touch()
+        config = make_config()
+        with patch("BRB.PushButton.subprocess.check_call") as mock_call:
+            deliverExternalRELACS(config, str(outputDir), "99_Foo_Bar")
+        mock_call.assert_not_called()
+
+    def test_failure_is_logged_not_raised(self, tmp_path):
+        outputDir = self._make_output_dir(tmp_path)
+        config = make_config()
+        with patch("BRB.PushButton.subprocess.check_call", side_effect=OSError("boom")):
+            deliverExternalRELACS(config, str(outputDir), "99_Foo_Bar")
+        assert not (outputDir / "external_delivery.done").exists()
+
+
+class TestRELACSExternalPaths:
+    """
+    End-to-end (with subprocess/network mocked) coverage of RELACS()'s
+    external-user code path: the sample-sheet glob and baseDir must resolve
+    without a PI group directory, and delivery must be triggered.
+    """
+
+    def _base_setup(self, tmp_path, ignore):
+        baseData = tmp_path / "base"
+        runID = "20260101_AV999999_1234567_lanes_1_2"
+        project = "99_Foo_Bar"
+        outputDir = (
+            baseData / runID / f"Analysis_{project}" / "ChIP-Seq_h38"
+            if ignore
+            else tmp_path
+            / "data"
+            / "foo"
+            / "sequencing_data"
+            / runID
+            / f"Analysis_{project}"
+            / "ChIP-Seq_h38"
+        )
+        outputDir.mkdir(parents=True)
+        sampleSheetContent = "Sample_1\tACGT\tsampleA\n"
+
+        config = make_config(
+            {
+                "Paths": {
+                    "baseData": str(baseData),
+                    "groupData": str(tmp_path / "data"),
+                },
+                "Options": {"runID": runID},
+            }
+        )
+        tuples = [["lib1", "sampleA", "ChIP RELACS high-throughput", ignore]]
+        return config, tuples, project, outputDir, sampleSheetContent
+
+    @patch("BRB.PushButton.createPath")
+    @patch("BRB.PushButton.deliverExternalRELACS")
+    @patch("BRB.PushButton.subprocess.check_call")
+    @patch("BRB.PushButton.glob.glob")
+    def test_external_uses_baseData_not_groupData(
+        self, mock_glob, mock_check_call, mock_deliver, mock_createPath, tmp_path
+    ):
+        config, tuples, project, outputDir, sheetContent = self._base_setup(
+            tmp_path, ignore=True
+        )
+        mock_createPath.return_value = str(outputDir)
+        (outputDir / "RELACS_sampleSheet.txt").write_text(sheetContent)
+        # 1 premux sample, 1 png already present => skip the demux subprocess call
+        (outputDir / "RELACS_demultiplexing").mkdir()
+        (outputDir / "RELACS_demultiplexing" / "sampleA_fig.png").write_text("x")
+
+        def glob_side_effect(pattern, recursive=False):
+            if "RELACS_Project_" in pattern:
+                return [
+                    "/dont_touch_this/short_runs/AVITI/AV1/run/RELACS_Project_99_Foo_Bar.txt"
+                ]
+            if pattern.endswith(".png") or "png" in pattern:
+                return [str(outputDir / "RELACS_demultiplexing" / "sampleA_fig.png")]
+            if "Sample_*" in pattern:
+                # This is the assertion target: baseDir must be baseData-rooted.
+                assert pattern.startswith(
+                    str(
+                        Path(config.get("Paths", "baseData"))
+                        / config.get("Options", "runID")
+                        / f"Project_{project}"
+                    )
+                )
+                return []
+            if "*.gz" in pattern:
+                return []
+            return []
+
+        mock_glob.side_effect = glob_side_effect
+        organism = ("Human", "h38", "GRCh38")
+        result = RELACS(config, "villa", project, organism, "ChIP-Seq", tuples)
+        assert result[1] == 0
+        mock_deliver.assert_called_once()
+
+    @patch("BRB.PushButton.createPath")
+    @patch("BRB.PushButton.deliverExternalRELACS")
+    @patch("BRB.PushButton.subprocess.check_call")
+    @patch("BRB.PushButton.glob.glob")
+    def test_internal_uses_groupData_and_skips_delivery(
+        self, mock_glob, mock_check_call, mock_deliver, mock_createPath, tmp_path
+    ):
+        config, tuples, project, outputDir, sheetContent = self._base_setup(
+            tmp_path, ignore=False
+        )
+        mock_createPath.return_value = str(outputDir)
+        (outputDir / "RELACS_sampleSheet.txt").write_text(sheetContent)
+        (outputDir / "RELACS_demultiplexing").mkdir()
+        (outputDir / "RELACS_demultiplexing" / "sampleA_fig.png").write_text("x")
+
+        groupSeqDir = tmp_path / "data" / "villa" / "sequencing_data"
+        groupSeqDir.mkdir(parents=True)
+
+        def glob_side_effect(pattern, recursive=False):
+            if "RELACS_Project_" in pattern:
+                return ["/dont_touch_this/short_runs/run/RELACS_Project_99_Foo_Bar.txt"]
+            if "Sample_*" in pattern:
+                assert str(tmp_path / "data" / "villa") in pattern
+                return []
+            # covers both the copyRELACS() png/html lookup and the
+            # RELACS-demultiplexed-fastq linking globs -- nothing to do here
+            return []
+
+        mock_glob.side_effect = glob_side_effect
+        organism = ("Human", "h38", "GRCh38")
+        result = RELACS(config, "villa", project, organism, "ChIP-Seq", tuples)
+        assert result[1] == 0
+        mock_deliver.assert_not_called()
+
+    @patch("BRB.PushButton.createPath")
+    @patch("BRB.PushButton.deliverExternalRELACS")
+    @patch("BRB.PushButton.glob.glob")
+    def test_sample_sheet_glob_matches_nested_avX_layout(
+        self, mock_glob, mock_deliver, mock_createPath, tmp_path
+    ):
+        """
+        Regression test for the /dont_touch_this/short_runs/AV*/AV*/<runID>
+        nesting fix (was AV*/<runID>, one level too shallow).
+        """
+        config, tuples, project, outputDir, _sheetContent = self._base_setup(
+            tmp_path, ignore=True
+        )
+        mock_createPath.return_value = str(outputDir)
+        seenPatterns = []
+
+        def glob_side_effect(pattern, recursive=False):
+            seenPatterns.append(pattern)
+            return []
+
+        mock_glob.side_effect = glob_side_effect
+        organism = ("Human", "h38", "GRCh38")
+        result = RELACS(config, "villa", project, organism, "ChIP-Seq", tuples)
+        assert result[1] == 1  # no sample sheet found -> expected failure
+        samplesheetPatterns = [p for p in seenPatterns if "RELACS_Project_" in p]
+        assert len(samplesheetPatterns) == 1
+        assert "AV*/AV*/" in samplesheetPatterns[0]


### PR DESCRIPTION
## Pull Request Names
Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Briefly:
Make sure the PR has a title that adheres to the following scheme:

 - fix: description of bugfix.  
 - feat: description of new feature.  
 - build: description of changes to the build system or external dependencies.  
 - chore: description of changes that do not modify src or test files.  
 - ci: description of changes to CI configuration files and scripts.  
 - docs: description of changes to documentation.  
 - style: description of changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).  
 - refactor: description of code changes that neither fixes a bug nor adds a feature.  
 - perf: description of changes that improve performance.  
 - test: description of changes to tests.  

If functionality is broken, append a `!` to the type, e.g. `fix!:` or `feat!:`, to indicate a breaking change.

## Description of Changes

BRB has always skipped every sample for projects that don't belong to a PI/group
under `$groupData` (external collaborators), regardless of library type --
`external.LibraryTypes` has existed in the ini for a long time but was always left
empty and never exercised. This came up concretely with a real external RELACS
ChIP-Seq project that BRB silently skipped; getting it processed by hand surfaced
several latent bugs in this never-exercised code path, and running it for real on
rapidus surfaced a further QC-sharing bug affecting internal runs too.

**New capability**
- `external.LibraryProtocols` (new ini key, comma-separated): protocol-level
  allowlist for external projects, matched via `startswith()` against the Parkour
  library protocol (e.g. `ChIP RELACS high-throughput`). This is deliberately
  protocol-scoped rather than reusing `LibraryTypes` at the type level, so plain
  (non-RELACS) external ChIP-Seq stays skipped unless separately opted in.
- Once an external RELACS run's pipeline succeeds, a new `deliverExternalRELACS()`
  step reclaims disk space by truncating the bulky, fully-reproducible
  intermediate FASTQs (`RELACS_demultiplexing/`, `FASTQ_Cutadapt/`), then packages
  the real results (BAMs, bigwigs, multiQC, run metadata -- no symlinks, no
  intermediates) into a `tar.gz` and delivers it via `fexsend` (new
  `external.fexRecipient` / `external.fexsendBin` ini keys). Guarded by a separate
  `external_delivery.done` marker (distinct from `analysis.done`), so if this step
  is interrupted after the pipeline itself succeeded, the next poll retries
  delivery instead of the outer `analysis.done` check silently skipping it forever.
- `copyRELACS()`'s QC diagnostics (multiQC report + per-sample RELACS
  demultiplexing figures) are now shipped to `seqFacDir`/`bioinfoCoreDir` for
  external projects too, same as internal ones -- these are sequencing-facility/
  bioinfo-core QC artifacts, not project deliverables, so unlike the raw/processed
  data itself there's no reason to withhold them for external runs.
  `copyCellRanger()` still skips both destinations entirely for external projects
  (no CellRanger library type is currently externally allow-listed, so this is
  precautionary), and `relinkFiles()` still skips its `bioinfoCoreDir` multiQC
  copy for external projects.

**Bugs fixed along the way** (found while getting a real external RELACS project
working end to end, and while verifying it live on rapidus against a copy of
that project's real output):
- `RELACS()`'s `baseDir` (source of the raw `Sample_*` dirs) always resolved via
  `groupData`/`getLatestSeqdir(group)`, which throws for external users (no
  `/data/<group>`). It now branches on the ignore flag exactly like
  `createPath()`/`linkFiles()` already do.
- The AVITI RELACS sample-sheet glob (`short_runs/AV*/<runID>/...`) didn't match
  the real on-disk nesting (`short_runs/AVITI/<instrument>/<runID>/...`), so it
  never found a sample sheet for **any** AVITI RELACS run, internal or external.
- `scATAC()` had the exact same unconditional-`groupData` bug as `RELACS()`'s
  `baseDir`; fixed the same way. Currently unreachable (no scATAC library type is
  externally allow-listed), but the same bug class the rest of this PR audits for.
- `relinkFiles()`/`copyCellRanger()` unconditionally copied QC artifacts (multiQC
  reports, CellRanger web summaries) into the internal-only
  `seqFacDir`/`bioinfoCoreDir` shares, for every pipeline (RNA, DNA, WGBS, ATAC,
  makePairs, scRNAseq, scATAC), with zero check for external status. They now skip
  that copy when the project is external, so external-user QC never leaks into
  internal PI tracking infrastructure via those two functions.
- **`copyRELACS()`'s `bioinfoCoreDir` copy never actually reached `bioinfoCoreDir`,
  for internal projects too.** It built the destination as
  `Path(bioinfoCoreDir) / nname`, but by that point `nname` had already been
  reassigned to an absolute `seqFacDir` path -- `pathlib`'s `/` operator discards
  the left operand entirely when the right one is absolute, so the file was
  silently copied to `seqFacDir` a second time instead. Found while running the
  fixed `copyRELACS()` for real against project 4019's delivered output on
  rapidus (the assertion in the new test below caught it immediately); fixed by
  computing the `bioinfoCoreDir` destination from the plain relative name before
  it's turned into an absolute `seqFacDir` path. Backfilled `bioinfoCoreDir` for
  project 4019 manually since the original manual run predates this fix.
- The external-gate check itself did substring matching against the raw
  comma-joined config string (`libraryType in config.get(...)`), not real list
  membership -- e.g. an allow-listed `"RNA-Seq"` would false-positive against
  `"stranded mRNA-Seq"`. Extracted into `parseExternalAllowlist()` /
  `isExternallyAllowed()`, now real list membership, independently unit tested.

**Config**: new `[external]` keys documented inline (the section previously had
none, unlike every other section); `LibraryProtocols` defaults to empty (opt-in).

**Tests**: `tests/test_PushButton.py` (new) covers the gate logic in isolation,
the `RELACS()`/`scATAC()` baseDir branching under both internal and external
tuples, the internal-share skip behavior for `copyCellRanger()`/`relinkFiles()`,
`copyRELACS()` always running (and actually reaching both `seqFacDir` and
`bioinfoCoreDir`) regardless of internal/external, and `deliverExternalRELACS()`
(truncation, tar contents, idempotency via the done marker, non-fatal failure
handling). `pytest tests/ -v` -- 23 passed. `ruff check` / `ruff format --check`
clean.

**Live-tested on rapidus**: ran the actual patched `RELACS()` against a safe copy
of the real, already-delivered project 4019 output, confirming the external gate,
`baseDir` resolution, and `deliverExternalRELACS()` (real tar + fexsend) all work
end to end; separately ran the fixed `copyRELACS()` against project 4019's real
output to backfill the seqFacDir/bioinfoCoreDir QC diagnostics that predate this
fix.
