### PR TITLE
feat: add install_brb.sh for versioned conda env installs from tags

### DIFF
--- a/install_brb.sh
+++ b/install_brb.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# install_brb.sh - create a version-named conda env for BigRedButton and
+# install a tagged release into it non-editably. Not part of the Python
+# package; a local ops convenience script run after pulling a new release.
+#
+# Usage: ./install_brb.sh [-t <tag>] [-p <prefix>] [-k <n>] [-f] [-h]
+set -euo pipefail
+usage() {
+  cat <<'EOF'
+Usage: install_brb.sh [-t <tag>] [-p <prefix>] [-k <n>] [-f] [-h]
+Create a version-named conda env (e.g. BRB_v0.5.0) and install
+BigRedButton into it from a git tag, then prune old versioned envs.
+Options:
+  -t <tag>     Install this tag instead of the latest reachable tag
+               (e.g. v0.5.0). Default: latest tag from `git describe`.
+  -p <prefix>  Env name prefix. Default: BRB_v
+  -k <n>       Number of versioned envs to keep (newest first). Default: 5
+  -f           Force: remove the target env first if it already exists.
+  -h           Show this help and exit.
+EOF
+}
+prefix="BRB_v"
+keep=5
+tag=""
+force=0
+while getopts ":t:p:k:fh" opt; do
+  case "$opt" in
+    t) tag="$OPTARG" ;;
+    p) prefix="$OPTARG" ;;
+    k) keep="$OPTARG" ;;
+    f) force=1 ;;
+    h) usage; exit 0 ;;
+    \?) echo "Unknown option: -$OPTARG" >&2; usage; exit 1 ;;
+    :) echo "Option -$OPTARG requires an argument" >&2; usage; exit 1 ;;
+  esac
+done
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$script_dir"
+command -v conda >/dev/null 2>&1 || { echo "conda not found on PATH" >&2; exit 1; }
+command -v git   >/dev/null 2>&1 || { echo "git not found on PATH" >&2; exit 1; }
+[ -d .git ] || { echo "$script_dir is not a git repository" >&2; exit 1; }
+git fetch --tags --quiet
+if [ -z "$tag" ]; then
+  tag="$(git describe --tags --abbrev=0)"
+fi
+if ! git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+  echo "Tag '$tag' not found (did you git fetch --tags?)" >&2
+  exit 1
+fi
+version="${tag#v}"
+envname="${prefix}${version}"
+# Build from a throwaway worktree at the tag rather than checking out this
+# repo in place - avoids touching the caller's working tree (which may hold
+# this very script, absent from older tags) or requiring it to be clean.
+worktree_dir="$(mktemp -d "${TMPDIR:-/tmp}/brb_install_${version}.XXXXXX")"
+cleanup() { git worktree remove --force "$worktree_dir" >/dev/null 2>&1 || rm -rf "$worktree_dir"; }
+trap cleanup EXIT
+echo "Checking out $tag into $worktree_dir..."
+git worktree add --quiet --detach "$worktree_dir" "$tag"
+[ -f "$worktree_dir/pyproject.toml" ] || { echo "pyproject.toml not found at $tag" >&2; exit 1; }
+# `conda env list` can lag behind the actual env directories on some shared
+# filesystems (observed in practice: a directory conda itself later refused
+# to recognize as an environment, and so wouldn't remove). Check the actual
+# directory on disk too, not just conda's own registry.
+envs_base="$(conda info --base)/envs"
+env_dir="$envs_base/$envname"
+env_exists=0
+{ conda env list | awk '{print $1}' | grep -qx "$envname"; } || [ -d "$env_dir" ] && env_exists=1
+if [ "$force" -eq 1 ]; then
+  echo "Removing existing env $envname (forced, if present)..."
+  conda env remove -n "$envname" --yes >/dev/null 2>&1 || true
+  # Belt and suspenders: conda env remove is a no-op (not an error) on an
+  # unregistered directory conda doesn't recognize as an environment, so
+  # fall back to removing it directly if it's still there.
+  [ -d "$env_dir" ] && rm -rf "$env_dir"
+elif [ "$env_exists" -eq 1 ]; then
+  echo "Env '$envname' already exists. Use -f to remove and recreate it." >&2
+  exit 1
+fi
+# BRB's dependencies (see pyproject.toml) are all pure-pip installable --
+# unlike dissectBCL, it needs no bioconda-only binaries, so the env just
+# needs a Python interpreter, not a full env.yml. git is required too: BRB
+# uses setuptools-scm for dynamic versioning, which shells out to `git
+# describe` during `pip install`, and pip's isolated build environment only
+# sees binaries present in this conda env (see the LookupError note in
+# README.md, and the same requirement in dissectBCL's env.yml).
+echo "Creating env $envname..."
+conda create -n "$envname" "python>=3.10" pip git --yes --quiet
+echo "Installing BigRedButton $tag into $envname..."
+conda run -n "$envname" pip install "$worktree_dir"
+echo "Pruning old '$prefix*' envs, keeping newest $keep..."
+mapfile -t old_envs < <(
+  conda env list | awk '{print $1}' \
+    | grep -E "^${prefix}[0-9]" \
+    | sort -Vr \
+    | tail -n +"$((keep + 1))"
+)
+for old in "${old_envs[@]:-}"; do
+  [ -z "$old" ] && continue
+  echo "Removing old env: $old"
+  conda env remove -n "$old" --yes
+done
+cat <<EOF
+Installed BigRedButton $tag into env '$envname'.
+To use it: conda activate $envname
+Remember to restart your BigRedButton process in the new env.
+EOF


### PR DESCRIPTION
## Pull Request Names
Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Briefly:
Make sure the PR has a title that adheres to the following scheme:

 - fix: description of bugfix.  
 - feat: description of new feature.  
 - build: description of changes to the build system or external dependencies.  
 - chore: description of changes that do not modify src or test files.  
 - ci: description of changes to CI configuration files and scripts.  
 - docs: description of changes to documentation.  
 - style: description of changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).  
 - refactor: description of code changes that neither fixes a bug nor adds a feature.  
 - perf: description of changes that improve performance.  
 - test: description of changes to tests.  

If functionality is broken, append a `!` to the type, e.g. `fix!:` or `feat!:`, to indicate a breaking change.

## Description of Changes

Adds `install_brb.sh`, a local ops convenience script (not part of the Python
package) that mirrors dissectBCL's `install_dissect.sh`, which has been in daily
use there. Builds a tagged release from a throwaway git worktree, installs it
into a version-named conda env (e.g. `BRB_v0.5.0`), then prunes old versioned
envs beyond a keep count. Same flags: `-t` tag, `-p` prefix (default `BRB_v`),
`-k` keep-count (default 5), `-f` force-reinstall, `-h` help.

Two differences from the dissectBCL version:
- No `env.yml` step. BRB's dependencies (see `pyproject.toml`) are all
  pure-pip installable, unlike dissectBCL which needs bioconda-only binaries
  (bbmap, kraken2, blast, ...). The env just needs `python>=3.10`, `pip`, and
  `git` (see below) -- `conda create`, no separate env file.
- `git` is still a required conda dependency, for a different reason than
  dissectBCL needs it: BRB uses setuptools-scm for dynamic versioning, which
  shells out to `git describe` during `pip install`, and pip's isolated build
  environment only sees binaries present in this conda env. This is the same
  `LookupError: setuptools-scm was unable to detect version` issue already
  documented in README.md's install instructions.

Also hardened the already-exists check past what dissectBCL's script does:
testing this against a real tag on rapidus, `conda env list` was observed to
lag behind the actual env directory badly enough that a second run without
`-f` silently proceeded instead of refusing, and left behind an env directory
conda itself no longer recognized as an environment (`conda env remove` then
failed with `DirectoryNotACondaEnvironmentError`). The exists check and
force-removal now also check the actual directory under `conda info
--base`/envs directly, with an `rm -rf` fallback if conda's own removal is a
no-op.

**Verified end to end** against the real `v0.5.0` tag on rapidus: env
creation, version resolution via setuptools-scm (`Successfully installed
BRB-0.5.0`), `pip install`, and the installed `BigRedButton --help` entry
point all work; confirmed the hardened exists-check now correctly refuses a
second run without `-f` and that `-f` cleanly reinstalls and leaves the env
properly registered/removable afterward. `shellcheck install_brb.sh` clean.
