### PR TITLE
feat: resolve PI group directory via Parkour deliver_to, not a hyphen guess

### DIFF
--- a/BRB/PushButton.py
+++ b/BRB/PushButton.py
@@ -927,8 +927,7 @@ def GetResults(config, project, libraries):
     """
     ignore = False
     try:
-        group = project.split("_")[-1].split("-")[0].lower()
-        group = BRB.misc.pacifier(group)
+        group = BRB.misc.resolveGroup(config, project)
         dataPath = Path(
             config.get("Paths", "groupData"),
             group,

--- a/BRB/misc.py
+++ b/BRB/misc.py
@@ -1,5 +1,65 @@
+import json
 import os
 import unicodedata
+
+import requests
+
+from BRB.logger import log
+
+
+def resolveDeliverTo(config):
+    """
+    Query Parkour's internal_pis endpoint for {PI name: deliver_to} overrides,
+    used to translate a PI's Parkour name into the periphery directory name
+    IT actually uses when the two diverge (dissectBCL has the same mechanism,
+    see misc.deliverDirName there).
+
+    Unlike dissectBCL's internal/external FEX routing decision, this is only
+    an enhancement on top of an already-working fallback (see GetResults() in
+    PushButton.py), so a failed/empty lookup here is not fatal: it's logged
+    and an empty map is returned, leaving the existing fallback in charge.
+    """
+    try:
+        response = requests.get(
+            config.get("Parkour", "InternalPIsURL"),
+            params={
+                "organizations": config.get(
+                    "Internals", "Organizations", fallback="MPI-IE"
+                )
+            },
+            auth=(config.get("Parkour", "user"), config.get("Parkour", "password")),
+            verify=config.get("Parkour", "cert"),
+        )
+        response.raise_for_status()
+        pis = response.json()["pis"]
+    except (requests.exceptions.RequestException, ValueError, KeyError) as e:
+        log.warning(
+            f"resolveDeliverTo: failed to fetch deliver_to overrides from "
+            f"Parkour, falling back to the surname heuristic for every PI: {e}"
+        )
+        return {}
+    if not isinstance(pis, dict):
+        # Older Parkour versions returned a bare list of names with no
+        # deliver_to info at all - nothing to override with.
+        return {}
+    return {name.lower(): token for name, token in pis.items() if token}
+
+
+def resolveGroup(config, project):
+    """
+    Resolve the periphery group (PI) directory name for a project string
+    like "4035_Demollin_Cabezas-Wallscheid": the PI's Parkour deliver_to
+    override, when config["Internals"]["deliverTo"] (populated by
+    resolveDeliverTo()) has one, else a best-effort guess by truncating a
+    hyphenated surname at the first hyphen (e.g. "cabezas-wallscheid" ->
+    "cabezas"). The fallback is only skipped once an override exists.
+    """
+    PI = project.split("_")[-1].lower()
+    deliverTo = json.loads(config.get("Internals", "deliverTo", fallback="{}"))
+    group = deliverTo.get(PI)
+    if group is None:
+        group = PI.split("-")[0]
+    return pacifier(group)
 
 
 def loadUserDictionary():

--- a/BRB/run.py
+++ b/BRB/run.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import json
 import os
 import sys
 from pathlib import Path
@@ -38,6 +39,13 @@ def run_brb(configfile, sequencer):
     while True:
         # Read the config file
         config = BRB.getConfig.getConfig(configfile)
+
+        # Resolve Parkour's deliver_to overrides for this run, used by
+        # PushButton.GetResults() to place a PI's data under the right
+        # periphery directory when it diverges from their Parkour name.
+        if not config.has_section("Internals"):
+            config.add_section("Internals")
+        config["Internals"]["deliverTo"] = json.dumps(BRB.misc.resolveDeliverTo(config))
 
         # Get the next flow cell to process, or sleep
         config, ParkourDict = BRB.findFinishedFlowCells.newFlowCell(config, sequencer)

--- a/BigRedButton.ini
+++ b/BigRedButton.ini
@@ -35,9 +35,16 @@ parallelProcesses=10
 [Parkour]
 QueryURL=http://someserver.com/api/analysis_list/analysis_list/
 ResultsURL=
+# Used to resolve deliver_to overrides: PIs whose /data directory diverges
+# from their Parkour name (see BRB.misc.resolveDeliverTo, PushButton.GetResults).
+InternalPIsURL=http://someserver.com/api/internal_pis/
 user=foo@bar.com
 password=supersecret
 cert=path/to/cert.pem
+
+[Internals]
+# Passed as the `organizations` param to InternalPIsURL above.
+Organizations=MPI-IE
 
 [Email]
 #Lists of recipients can be comma separated

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,100 @@
+import configparser
+import json
+from unittest.mock import Mock, patch
+
+import requests
+
+from BRB.misc import resolveDeliverTo, resolveGroup
+
+
+def _make_config(deliver_to=None):
+    config = configparser.ConfigParser()
+    config["Parkour"] = {
+        "InternalPIsURL": "https://parkour-demo.example.org/api/internal_pis/",
+        "user": "jefke",
+        "password": "123",
+        "cert": "",
+    }
+    config["Internals"] = {"Organizations": "MPI-IE"}
+    if deliver_to is not None:
+        config["Internals"]["deliverTo"] = json.dumps(deliver_to)
+    return config
+
+
+class TestResolveDeliverTo:
+    @patch("BRB.misc.requests.get")
+    def test_returns_only_non_empty_overrides(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "pis": {
+                "cabezas-wallscheid": "cabezas",
+                "akhtar": None,
+                "alhaj abed": "alhajabed",
+            }
+        }
+        mock_get.return_value = mock_resp
+        config = _make_config()
+
+        result = resolveDeliverTo(config)
+
+        assert result == {"cabezas-wallscheid": "cabezas", "alhaj abed": "alhajabed"}
+        mock_get.assert_called_once_with(
+            "https://parkour-demo.example.org/api/internal_pis/",
+            params={"organizations": "MPI-IE"},
+            auth=("jefke", "123"),
+            verify="",
+        )
+
+    @patch("BRB.misc.requests.get")
+    def test_network_failure_falls_back_to_empty_map(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError("boom")
+        config = _make_config()
+
+        assert resolveDeliverTo(config) == {}
+
+    @patch("BRB.misc.requests.get")
+    def test_non_200_falls_back_to_empty_map(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 error"
+        )
+        mock_get.return_value = mock_resp
+        config = _make_config()
+
+        assert resolveDeliverTo(config) == {}
+
+    @patch("BRB.misc.requests.get")
+    def test_legacy_bare_list_response_has_no_overrides(self, mock_get):
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"pis": ["akhtar", "cabezas-wallscheid"]}
+        mock_get.return_value = mock_resp
+        config = _make_config()
+
+        assert resolveDeliverTo(config) == {}
+
+
+class TestResolveGroup:
+    def test_uses_deliver_to_override_when_present(self):
+        config = _make_config(deliver_to={"cabezas-wallscheid": "cabezas"})
+        assert resolveGroup(config, "4035_Demollin_Cabezas-Wallscheid") == "cabezas"
+
+    def test_falls_back_to_hyphen_truncation_without_override(self):
+        config = _make_config(deliver_to={})
+        assert resolveGroup(config, "4035_Demollin_Cabezas-Wallscheid") == "cabezas"
+
+    def test_falls_back_when_deliverTo_key_missing_entirely(self):
+        config = _make_config()  # no "Internals"/"deliverTo" key set at all
+        assert resolveGroup(config, "4035_Demollin_Cabezas-Wallscheid") == "cabezas"
+
+    def test_simple_surname_unaffected(self):
+        config = _make_config(deliver_to={})
+        assert resolveGroup(config, "1234_jdoe_manke") == "manke"
+
+    def test_override_wins_even_when_it_differs_from_fallback_guess(self):
+        # A PI whose deliver_to override isn't just "truncate at the first
+        # hyphen" - the override must take priority over the guess.
+        config = _make_config(deliver_to={"alhaj abed": "alhajabed"})
+        assert resolveGroup(config, "9001_jdoe_AlHaj Abed") == "alhajabed"


### PR DESCRIPTION
## Pull Request Names
Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Briefly:
Make sure the PR has a title that adheres to the following scheme:

 - fix: description of bugfix.  
 - feat: description of new feature.  
 - build: description of changes to the build system or external dependencies.  
 - chore: description of changes that do not modify src or test files.  
 - ci: description of changes to CI configuration files and scripts.  
 - docs: description of changes to documentation.  
 - style: description of changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).  
 - refactor: description of code changes that neither fixes a bug nor adds a feature.  
 - perf: description of changes that improve performance.  
 - test: description of changes to tests.  

If functionality is broken, append a `!` to the type, e.g. `fix!:` or `feat!:`, to indicate a breaking change.

## Description of Changes

`PushButton.GetResults()` derived the periphery group (PI) directory for a project with:

```python
group = project.split("_")[-1].split("-")[0].lower()
```

A hardcoded guess that a PI's `/data` directory name is whatever precedes the first hyphen in their surname. It happens to work for `Cabezas-Wallscheid` → `cabezas` (the case that prompted this PR — see [maxplanck-ie/dissectBCL#304](https://github.com/maxplanck-ie/dissectBCL/pull/304) for the incident), but it has no connection to Parkour's actual data, and would silently misroute any PI whose divergence isn't "truncate at the first hyphen" (e.g. a two-word surname).

dissectBCL already has (in-flight, [maxplanck-ie/dissectBCL#294](https://github.com/maxplanck-ie/dissectBCL/pull/294)) a proper mechanism for this: Parkour's `internal_pis` endpoint returns a `{PI name: deliver_to}` map for exactly the PIs whose `/data` directory diverges from their Parkour name. This PR brings the same mechanism to BigRedButton:

- `BRB.misc.resolveDeliverTo(config)` fetches that map from Parkour. Unlike dissectBCL's internal/external FEX routing decision, this is only an enhancement over an already-working fallback, so a failed/empty lookup here is not fatal — it's logged and an empty map is returned.
- `BRB.misc.resolveGroup(config, project)` prefers a `deliver_to` override when Parkour has one for a PI, falling back to the old hyphen-truncation heuristic only when it doesn't (yet). `GetResults()` now calls this instead of inlining the guess.
- `run.py` resolves the map once per polling loop and stores it in `config["Internals"]["deliverTo"]`, mirroring dissectBCL's own `getConf()`.
- `BigRedButton.ini` documents the two new config keys this needs (`[Parkour] InternalPIsURL`, `[Internals] Organizations`).

This keeps today's behavior unchanged for PIs Parkour doesn't have an override for yet, and automatically switches to the authoritative value as `deliver_to` gets set for more PIs in Parkour — no per-PI patches needed in this codebase going forward.

## Test plan
- `tests/test_misc.py`: `resolveDeliverTo` (dict-shape parsing, non-empty-override filtering, legacy bare-list response, network/HTTP-error fallback to `{}`) and `resolveGroup` (override present, override absent → fallback, missing config key entirely, simple surname unaffected, override wins even when it disagrees with the fallback guess).
- Full suite green (48 tests).