### PR TITLE
fix: nest aviti scanning, output, and logs under the matching serial-ID subdir

### DIFF
--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -101,8 +101,16 @@ def newFlowCell(config, sequencer=None):
             base_path = str(Path(d).parents[0])
             seq_type = detect_sequencer_type(base_path)
             config.set("Options", "sequencerType", seq_type)
-            config.set("Paths", "baseData", baseData)
-            config.set("Paths", "logPath", logPath)
+
+            if platform == "aviti":
+                # Output and logs mirror the serial-ID (e.g. AV251009)
+                # subdir that baseData_aviti holds this flowcell under.
+                serialID = Path(d).parents[1].name
+                config.set("Paths", "baseData", str(Path(baseData, serialID)))
+                config.set("Paths", "logPath", str(Path(logPath, serialID)))
+            else:
+                config.set("Paths", "baseData", baseData)
+                config.set("Paths", "logPath", logPath)
 
             if not flowCellProcessed(config):
                 found = True

--- a/BRB/findFinishedFlowCells.py
+++ b/BRB/findFinishedFlowCells.py
@@ -79,7 +79,15 @@ def newFlowCell(config, sequencer=None):
 
     print("Checking for new flowcells...")
     for platform, baseData, logPath in platforms:
-        dirs = glob.glob(f"{baseData}/*/fastq.made")
+        # aviti's baseData is the shared parent of multiple instrument
+        # directories (e.g. AV251009, AV261103), so run directories sit one
+        # level deeper than under illumina's single-instrument baseData.
+        pattern = (
+            f"{baseData}/*/*/fastq.made"
+            if platform == "aviti"
+            else f"{baseData}/*/fastq.made"
+        )
+        dirs = glob.glob(pattern)
         found = False
         for d in dirs:
             # Get the flow cell ID (e.g., 150416_SN7001180_0196_BC605HACXX)

--- a/BRB/run.py
+++ b/BRB/run.py
@@ -50,6 +50,7 @@ def run_brb(configfile, sequencer):
         logFile = Path(
             config["Paths"]["logPath"], config.get("Options", "runID") + ".log"
         )
+        logFile.parent.mkdir(parents=True, exist_ok=True)
         print(f"Logging into: {logFile}")
         setLog(logFile)
 

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -153,8 +153,10 @@ def platform_dirs(tmp_path_factory):
     aviti_base = fp / "aviti"
     (illu_base / "20250101_illumina_runXXX").mkdir(parents=True)
     (illu_base / "20250101_illumina_runXXX" / "fastq.made").touch()
-    (aviti_base / "20250101_AV999999_runYYY").mkdir(parents=True)
-    (aviti_base / "20250101_AV999999_runYYY" / "fastq.made").touch()
+    # aviti_base is the shared parent of multiple instruments, so run
+    # directories sit one level deeper than under illumina's baseData.
+    (aviti_base / "AV999999" / "20250101_AV999999_runYYY").mkdir(parents=True)
+    (aviti_base / "AV999999" / "20250101_AV999999_runYYY" / "fastq.made").touch()
     return illu_base, aviti_base
 
 
@@ -189,7 +191,7 @@ class TestNewFlowCellSequencerGating:
         assert config.get("Paths", "baseData") == str(illu_base)
         assert config.get("Paths", "logPath") == str(illu_base / "LOG")
         assert not Path(
-            aviti_base, "20250101_AV999999_runYYY", "analysis.done"
+            aviti_base, "AV999999", "20250101_AV999999_runYYY", "analysis.done"
         ).exists()
 
     @patch("BRB.findFinishedFlowCells.queryParkour")
@@ -204,3 +206,22 @@ class TestNewFlowCellSequencerGating:
         assert config.get("Paths", "baseData") == str(aviti_base)
         assert config.get("Paths", "logPath") == str(aviti_base / "LOG")
         assert not Path(illu_base, "20250101_illumina_runXXX", "analysis.done").exists()
+
+    @patch("BRB.findFinishedFlowCells.queryParkour")
+    def test_aviti_finds_runs_across_multiple_instruments(self, mock_query, tmp_path):
+        """Regression test: baseData_aviti is the shared parent of several
+        instrument directories (e.g. AV251009, AV261103), so a run's
+        fastq.made sits two levels below baseData_aviti, not one."""
+        illu_base = tmp_path / "illumina"
+        aviti_base = tmp_path / "aviti"
+        illu_base.mkdir()
+        (aviti_base / "AV251009" / "20260818_AV251009_runZZZ").mkdir(parents=True)
+        (aviti_base / "AV251009" / "20260818_AV251009_runZZZ" / "fastq.made").touch()
+
+        mock_query.return_value = {"some": "data"}
+        config = create_platform_conf(illu_base, aviti_base)
+
+        config, ParkourDict = newFlowCell(config, sequencer="aviti")
+
+        assert config.get("Options", "runID") == "20260818_AV251009_runZZZ"
+        assert ParkourDict == {"some": "data"}

--- a/tests/test_findFinishedFlowCells.py
+++ b/tests/test_findFinishedFlowCells.py
@@ -203,8 +203,8 @@ class TestNewFlowCellSequencerGating:
         config, _ = newFlowCell(config, sequencer="aviti")
 
         assert config.get("Options", "runID") == "20250101_AV999999_runYYY"
-        assert config.get("Paths", "baseData") == str(aviti_base)
-        assert config.get("Paths", "logPath") == str(aviti_base / "LOG")
+        assert config.get("Paths", "baseData") == str(aviti_base / "AV999999")
+        assert config.get("Paths", "logPath") == str(aviti_base / "LOG" / "AV999999")
         assert not Path(illu_base, "20250101_illumina_runXXX", "analysis.done").exists()
 
     @patch("BRB.findFinishedFlowCells.queryParkour")
@@ -225,3 +225,34 @@ class TestNewFlowCellSequencerGating:
 
         assert config.get("Options", "runID") == "20260818_AV251009_runZZZ"
         assert ParkourDict == {"some": "data"}
+
+    @patch("BRB.findFinishedFlowCells.queryParkour")
+    def test_aviti_baseData_and_logPath_nest_under_serial_id(
+        self, mock_query, tmp_path
+    ):
+        """Regression test: baseData_aviti/logPath_aviti are the shared
+        parent of multiple instruments. flowCellProcessed/markFinished and
+        run.py's logfile path all build off config["Paths"]["baseData"]/
+        ["logPath"], so those must already be nested under the matching
+        serial-ID (e.g. AV251009), or analysis.done and the logfile get
+        written to a flat path whose parent doesn't exist."""
+        illu_base = tmp_path / "illumina"
+        aviti_base = tmp_path / "aviti"
+        aviti_log = tmp_path / "aviti_log"
+        illu_base.mkdir()
+        runID = "20260818_AV251009_runZZZ"
+        (aviti_base / "AV251009" / runID).mkdir(parents=True)
+        (aviti_base / "AV251009" / runID / "fastq.made").touch()
+
+        mock_query.return_value = {"some": "data"}
+        config = create_platform_conf(illu_base, aviti_base)
+        config.set("Paths", "logPath_aviti", str(aviti_log))
+
+        config, _ = newFlowCell(config, sequencer="aviti")
+
+        assert config.get("Paths", "baseData") == str(aviti_base / "AV251009")
+        assert config.get("Paths", "logPath") == str(aviti_log / "AV251009")
+        # flowCellProcessed must resolve to the real, nested run directory.
+        assert Path(config.get("Paths", "baseData"), runID) == (
+            aviti_base / "AV251009" / runID
+        )


### PR DESCRIPTION
## Summary
`baseData_aviti`/`logPath_aviti` were changed on 2026-08-20 to point at the shared parent of multiple Aviti instrument directories (`AV251009`, `AV261103`) instead of a single instrument. Two things in `newFlowCell()` still assumed the old flat, single-instrument layout, mirroring the same class of bug dissectBCL fixed in [#308](https://github.com/maxplanck-ie/dissectBCL/pull/308) / [#309](https://github.com/maxplanck-ie/dissectBCL/pull/309):

1. **Scanning glob was one level too shallow.** `{baseData}/*/fastq.made` matched `<instrument>/fastq.made`, but real runs sit at `<instrument>/<run>/fastq.made`. Result: **every Aviti flowcell has been invisible to BRB since the config change** (confirmed: 70 flowcells match a two-level glob, 0 match the one-level glob currently in production).
2. **`baseData`/`logPath` weren't nested under the matching instrument either**, so once a flowcell *is* found, `flowCellProcessed`/`markFinished`'s `analysis.done` path and `run.py`'s logfile path both get built flat (`baseData_aviti/<run>/...`), which doesn't exist. Confirmed live: re-running against the real backlog under a test conda env hit `FileNotFoundError` opening `.../ElementBiosciences/LOG_BRB/20251128_AV251009_2511489440_lanes_1_2.log`.

Fixes, matching dissectBCL's approach:
- Aviti uses a two-level glob (`{baseData}/*/*/fastq.made`); Illumina is unchanged (single instrument, still one level).
- For Aviti, `config["Paths"]["baseData"]`/`["logPath"]` are set to `<baseData_aviti>/<serialID>` / `<logPath_aviti>/<serialID>`, derived from the matched run's parent instrument directory — this fixes the completion check, `markFinished`, and the logfile path all at once, since they all build off those two config values.
- `run.py` now `mkdir(parents=True, exist_ok=True)`s the logfile's parent directory before opening it (matches dissectBCL #308), so a never-before-logged instrument doesn't crash the run.

## Test plan
- [x] `test_aviti_finds_runs_across_multiple_instruments` — reproduces the real multi-instrument layout, fails without the glob fix
- [x] `test_aviti_baseData_and_logPath_nest_under_serial_id` — proves `baseData`/`logPath` resolve to the instrument-nested directory, fails without the nesting fix
- [x] Updated `platform_dirs` fixture/tests to the real (nested) Aviti layout
- [x] `pytest tests/` — 41 passed
- [x] `ruff check` / `ruff format` clean