### PR TITLE
ci: enforce conventional-commit PR titles

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,16 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request Names
Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

Briefly:
Make sure the PR has a title that adheres to the following scheme:

 - fix: description of bugfix.  
 - feat: description of new feature.  
 - build: description of changes to the build system or external dependencies.  
 - chore: description of changes that do not modify src or test files.  
 - ci: description of changes to CI configuration files and scripts.  
 - docs: description of changes to documentation.  
 - style: description of changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc).  
 - refactor: description of code changes that neither fixes a bug nor adds a feature.  
 - perf: description of changes that improve performance.  
 - test: description of changes to tests.  

If functionality is broken, append a `!` to the type, e.g. `fix!:` or `feat!:`, to indicate a breaking change.

## Description of Changes

The PR template already documents the conventional-commits requirement for
PR titles, but nothing technically enforced it — a title without a type
prefix went unnoticed on #145 until caught by hand. Since PRs here are
squash-merged with the PR title as the resulting commit message, and
release-please parses that commit message to decide the next version bump,
an unprefixed title silently breaks the release automation rather than
just looking wrong.

Adds a CI check (`amannn/action-semantic-pull-request`) that validates the
PR title on open/edit/synchronize and fails the check if it doesn't match
the scheme above.
